### PR TITLE
[network] No error if no IPv6 interface is found

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -21,7 +21,10 @@ func getNetworkInfo() (networkInfo map[string]interface{}, err error) {
 	if err != nil {
 		return networkInfo, err
 	}
-	networkInfo["ipaddressv6"] = ipAddressV6
+	// We append an IPv6 address to the payload only if IPv6 is enabled
+	if ipAddressV6 != "" {
+		networkInfo["ipaddressv6"] = ipAddressV6
+	}
 
 	return
 }

--- a/network/network_common.go
+++ b/network/network_common.go
@@ -54,7 +54,12 @@ func externalIpv6Address() (string, error) {
 			return ip.String(), nil
 		}
 	}
-	return "", errors.New("not connected to the network")
+
+	// We don't return an error if no IPv6 interface has been found. Indeed,
+	// some orgs just don't have IPv6 enabled. If there's a network error, it
+	// will pop out when getting the Mac address and/or the IPv4 address
+	// (before this function's call; see network.go -> getNetworkInfo())
+	return "", nil
 }
 
 type IpAddress struct{}


### PR DESCRIPTION
We stop propagating an error **if No IPv6 address is found**. We just don't
append the IPv6 address to the 'network' map. The payload just contains
IPv4 and and MAC addresses. Before, having no IPv6 was causing the whole
'network' map to be excluded from the payload, which bothered an host 
willing to use the {{ host.ip }} in his monitors.

This solves the issue an org was having because he doesn't have an IPv6
interface enabled on his CentOS6 machines.