### PR TITLE
Improve signal handling for `df` timeout

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -15,8 +15,8 @@ func getFileSystemInfo() (interface{}, error) {
 	/* Grab filesystem data from df	*/
 	cmd := exec.Command("df", dfOptions...)
 
-	outCh := make(chan []byte)
-	errCh := make(chan error)
+	outCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
 
 	var out interface{}
 	var err error
@@ -24,28 +24,33 @@ func getFileSystemInfo() (interface{}, error) {
 	go func() {
 		_out, _err := cmd.Output()
 		if _err != nil {
-			errCh <- _err
+			errCh <- fmt.Errorf("df failed to collect filesystem data: %s", _err)
 			return
 		}
 		outCh <- _out
 	}()
 
-	select {
-	case res := <-outCh:
-		if res != nil {
-			out, err = parseDfOutput(string(res))
-		} else {
-			out, err = nil, fmt.Errorf("df process timed out and was killed!")
+WAIT:
+	for {
+		select {
+		case res := <-outCh:
+			if res != nil {
+				out, err = parseDfOutput(string(res))
+			} else {
+				out, err = nil, fmt.Errorf("df failed to collect filesystem data")
+			}
+			break WAIT
+		case err = <-errCh:
+			out = nil
+			break WAIT
+		case <-time.After(2 * time.Second):
+			// Kill the process if it takes too long
+			if killErr := cmd.Process.Kill(); killErr != nil {
+				log.Fatal("failed to kill:", killErr)
+				// Force goroutine to exit
+				<-outCh
+			}
 		}
-	case err = <-errCh:
-		out = nil
-	case <-time.After(5 * time.Second):
-		// Kill the process if it takes too long
-		if killErr := cmd.Process.Kill(); killErr != nil {
-			log.Fatal("failed to kill:", killErr)
-		}
-		//Let goroutine exit
-		<-outCh
 	}
 
 	return out, err

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -1,0 +1,72 @@
+package filesystem
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func MockSlowGetFileSystemInfo() (interface{}, error) {
+	/* Run a command that will definitely time out */
+	cmd := exec.Command("sleep", "5")
+
+	outCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+
+	var out interface{}
+	var err error
+
+	go func() {
+		_out, _err := cmd.Output()
+		if _err != nil {
+			errCh <- fmt.Errorf("df failed to collect filesystem data: %s", _err)
+			return
+		}
+		outCh <- _out
+	}()
+
+WAIT:
+	for {
+		select {
+		case res := <-outCh:
+			if res != nil {
+				out, err = parseDfOutput(string(res))
+			} else {
+				out, err = nil, fmt.Errorf("df failed to collect filesystem data")
+			}
+			break WAIT
+		case err = <-errCh:
+			out = nil
+			break WAIT
+		case <-time.After(2 * time.Second):
+			// Kill the process if it takes too long
+			if killErr := cmd.Process.Kill(); killErr != nil {
+				log.Fatal("failed to kill:", killErr)
+				// Force goroutine to exit
+				<-outCh
+			}
+		}
+	}
+
+	return out, err
+}
+
+func TestSlowGetFileSystemInfo(t *testing.T) {
+	out, err := MockSlowGetFileSystemInfo()
+	if !reflect.DeepEqual(out, nil) {
+		t.Fatalf("Failed! out should be nil. Instead it's %s", out)
+	}
+	if !reflect.DeepEqual(err, fmt.Errorf("df failed to collect filesystem data: signal: killed")) {
+		t.Fatalf("Failed! Wrong error: %s", err)
+	}
+}
+
+func TestGetFileSystemInfo(t *testing.T) {
+	_, err := getFileSystemInfo()
+	if !reflect.DeepEqual(err, nil) {
+		t.Fatalf("getFileSystemInfo failed: %s", err)
+	}
+}


### PR DESCRIPTION
PR #14 actually didn't work as expected, exiting with the following in the event of timeouts:
```
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan receive]:
github.com/DataDog/gohai/filesystem.getFileSystemInfo(0x0, 0x0, 0x0, 0x0)
    /home/vagrant/workspace/go/src/github.com/DataDog/gohai/filesystem/filesystem.go:49 +0x61a
github.com/DataDog/gohai/filesystem.(*FileSystem).Collect(0x6556d8, 0x0, 0x0, 0x0, 0x0)
    /home/vagrant/workspace/go/src/github.com/DataDog/gohai/filesystem/filesystem_common.go:12 +0x43
main.Collect(0xc20803a3f0, 0x0, 0x0)
    /home/vagrant/workspace/go/src/github.com/DataDog/gohai/gohai.go:32 +0xe4
main.main()
    /home/vagrant/workspace/go/src/github.com/DataDog/gohai/gohai.go:44 +0x1f

goroutine 5 [chan send]:
github.com/DataDog/gohai/filesystem.func·001()
    /home/vagrant/workspace/go/src/github.com/DataDog/gohai/filesystem/filesystem.go:28 +0xb3
created by github.com/DataDog/gohai/filesystem.getFileSystemInfo
    /home/vagrant/workspace/go/src/github.com/DataDog/gohai/filesystem/filesystem.go:32 +0x267
```

This PR should fix the deadlock issue, by properly handling the signals in `select`. It also propagates the error message to `dd-agent` and adds a test for the timeout.