### PR TITLE
Add version to json output, and cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ $ go get github.com/laher/goxc
 $ goxc -bc='linux,darwin,windows' -d=[BUILD_DIR]
 ```
 
+## Build with version info
+
+To build Gohai with version information, use `make.go`:
+
+```sh
+$ go run make.go
+```
+
+It will build gohai using the `go build` command, with the version info passed through `-ldflags`.
+
 ## See Also
 
   * [facter](https://github.com/puppetlabs/facter)

--- a/gohai.go
+++ b/gohai.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"flag"
+	"fmt"
 	"log"
 	"os"
 
@@ -25,6 +28,18 @@ var collectors = []Collector{
 	&platform.Platform{},
 }
 
+var options struct {
+	version bool
+}
+
+// version information filled in at build time
+var (
+	buildDate string
+	gitCommit string
+	gitBranch string
+	goVersion string
+)
+
 func Collect() (result map[string]interface{}, err error) {
 	result = make(map[string]interface{})
 
@@ -37,10 +52,52 @@ func Collect() (result map[string]interface{}, err error) {
 		result[collector.Name()] = c
 	}
 
+	result["gohai"] = versionMap()
+
 	return
 }
 
+func versionMap() (result map[string]interface{}) {
+	result = make(map[string]interface{})
+
+	result["git_hash"] = gitCommit
+	result["git_branch"] = gitBranch
+	result["build_date"] = buildDate
+	result["go_version"] = goVersion
+
+	return
+}
+
+func versionString() string {
+	var buf bytes.Buffer
+
+	if gitCommit != "" {
+		fmt.Fprintf(&buf, "Git hash: %s\n", gitCommit)
+	}
+	if gitBranch != "" {
+		fmt.Fprintf(&buf, "Git branch: %s\n", gitBranch)
+	}
+	if buildDate != "" {
+		fmt.Fprintf(&buf, "Build date: %s\n", buildDate)
+	}
+	if goVersion != "" {
+		fmt.Fprintf(&buf, "Go Version: %s\n", goVersion)
+	}
+
+	return buf.String()
+}
+
+func init() {
+	flag.BoolVar(&options.version, "version", false, "Show version information and exit")
+	flag.Parse()
+}
+
 func main() {
+	if options.version {
+		fmt.Printf("%s", versionString())
+		os.Exit(0)
+	}
+
 	gohai, err := Collect()
 
 	if err != nil {

--- a/make.go
+++ b/make.go
@@ -1,0 +1,46 @@
+// +build ignore
+
+// Builds Gohai with version information
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func commandOutput(name string, args ...string) string {
+	out, err := exec.Command(name, args...).Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+func main() {
+	gobin := "go"
+	if len(os.Args) > 1 {
+		gobin = os.Args[1]
+	}
+
+	date := time.Now().Format(time.UnixDate)
+	commit := commandOutput("git", "rev-parse", "--short", "HEAD")
+	branch := commandOutput("git", "rev-parse", "--abbrev-ref", "HEAD")
+	go_version := commandOutput(gobin, "version")
+
+	// NB: Starting from Go 1.5, the syntax of these ldflags changes from `-X main.var 'value'` to `-X 'main.var=value'`
+	// For reference see https://github.com/golang/go/issues/12338
+	ldflags := fmt.Sprintf("-X main.buildDate '%s' -X main.gitCommit '%s' -X main.gitBranch '%s' -X main.goVersion '%s'", date, commit, branch, go_version)
+
+	cmd := exec.Command(gobin, "build", "-a", "-ldflags", ldflags, "gohai.go")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
To build Gohai with the version info, use:

```
go run make.go
```

otherwise the info is blank.

I've also updated our build repos to support this (see related PRs below).

The info is available in the json output and through a cli option.
Example usage:
```
$ gohai --version
Git hash: 95d122d
Git branch: olivielpeau/version
Build date: Tue Dec  1 17:41:55 EST 2015
Go Version: go version go1.4.2 darwin/amd64
```