### PR TITLE
[cpu] Count cores by NumberOfLogicalProcessors

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -23,7 +23,7 @@ func getCpuInfo() (cpuInfo map[string]string, err error) {
 	cpuInfo = make(map[string]string)
 
 	cpu, err := utils.WindowsWMICommand("CPU",
-		"CurrentClockSpeed", "Name", "NumberOfCores",
+		"CurrentClockSpeed", "Name", "NumberOfLogicalProcessors",
 		"Caption", "Manufacturer")
 	if err != nil {
 		return


### PR DESCRIPTION
Currently we are counting the number of cores by the NumberOfCores stat. Unfortunately, if the processor has hyperthreading enabled, then NumberOfCores will show as less than NumberOfLogicalProcessors. This showed up in a situation where a Windows AMI launched in a c4.4xlarge instance (which should have 16 cores), was reporting to have 8 cores. Sure enough, when replicating, NumberOfLogicalProcessors correctly shows 16 cores.