### PR TITLE
[cpu] Add count for number of logical processors

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -10,6 +10,7 @@ var cpuMap = map[string]string{
 	"machdep.cpu.vendor":       "vendor_id",
 	"machdep.cpu.brand_string": "model_name",
 	"hw.physicalcpu":           "cpu_cores",
+	"hw.logicalcpu":            "cpu_logical_processors",
 	"hw.cpufrequency":          "mhz",
 	"machdep.cpu.family":       "family",
 	"machdep.cpu.model":        "model",

--- a/cpu/cpu_linux.go
+++ b/cpu/cpu_linux.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"os"
 	"regexp"
-	"strconv"
 )
 
 var cpuMap = map[string]string{
 	"vendor_id":  "vendor_id",
 	"model name": "model_name",
+	"cpu cores":  "cpu_cores",
+	"siblings":   "cpu_logical_processors",
 	"cpu MHz\t":  "mhz",
 	"cache size": "cache_size",
 	"cpu family": "family",
@@ -38,22 +39,14 @@ func getCpuInfo() (cpuInfo map[string]string, err error) {
 
 	cpuInfo = make(map[string]string)
 
-	// count # of occurences to get # of cores, since the field
-	// "cpu cores" isn't reliable
-	numCores := 0
-
 	for _, line := range lines[1:] {
 		pair := regexp.MustCompile("\t: ").Split(line, 2)
 
 		key, ok := cpuMap[pair[0]]
 		if ok {
 			cpuInfo[key] = pair[1]
-			if pair[0] == "vendor_id" {
-				numCores += 1
-			}
 		}
 	}
-	cpuInfo["cpu_cores"] = strconv.Itoa(numCores)
 
 	return
 }

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -24,13 +24,14 @@ func getCpuInfo() (cpuInfo map[string]string, err error) {
 
 	cpu, err := utils.WindowsWMICommand("CPU",
 		"CurrentClockSpeed", "Name", "NumberOfCores",
-		"Caption", "Manufacturer")
+		"NumberOfLogicalProcessors", "Caption", "Manufacturer")
 	if err != nil {
 		return
 	}
 	cpuInfo["mhz"] = cpu["CurrentClockSpeed"]
 	cpuInfo["model_name"] = cpu["Name"]
 	cpuInfo["cpu_cores"] = cpu["NumberOfCores"]
+	cpuInfo["cpu_logical_processors"] = cpu["NumberOfLogicalProcessors"]
 	cpuInfo["vendor_id"] = cpu["Manufacturer"]
 
 	caption := fmt.Sprintf(" %s ", cpu["Caption"])


### PR DESCRIPTION
Gohai reports the number of physical cores on the host; which is does correctly. However, when using AWS, they provision instances with some number of vCPUs, which causes some confusion. Each vCPU is just half of a physical core, so if there are 16 vCPUs on an instance, then gohai will report 8 cores, because there are only 8 physical cores, and 16 logical processors.

When you test this on a Windows AMI with 16 vCPUs, you'll see that wmi shows NumberOfCores at 8 and NumberOfLogicalProcessors at 16.

Shall we add another count for this?