### PR TITLE
Add process collector

### DIFF
--- a/gohai.go
+++ b/gohai.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/DataDog/gohai/cpu"
 	"github.com/DataDog/gohai/filesystem"
 	"github.com/DataDog/gohai/memory"
 	"github.com/DataDog/gohai/network"
 	"github.com/DataDog/gohai/platform"
+	"github.com/DataDog/gohai/processes"
 )
 
 type Collector interface {
@@ -20,16 +22,24 @@ type Collector interface {
 	Collect() (interface{}, error)
 }
 
+type SelectedCollectors map[string]bool
+
 var collectors = []Collector{
 	&cpu.Cpu{},
 	&filesystem.FileSystem{},
 	&memory.Memory{},
 	&network.Network{},
 	&platform.Platform{},
+	&processes.Processes{},
 }
 
-var options struct {
+var options = struct {
+	only    SelectedCollectors
+	exclude SelectedCollectors
 	version bool
+}{
+	only:    make(SelectedCollectors),
+	exclude: make(SelectedCollectors),
 }
 
 // version information filled in at build time
@@ -44,12 +54,14 @@ func Collect() (result map[string]interface{}, err error) {
 	result = make(map[string]interface{})
 
 	for _, collector := range collectors {
-		c, err := collector.Collect()
-		if err != nil {
-			log.Printf("[%s] %s", collector.Name(), err)
-			continue
+		if shouldCollect(collector) {
+			c, err := collector.Collect()
+			if err != nil {
+				log.Printf("[%s] %s", collector.Name(), err)
+				continue
+			}
+			result[collector.Name()] = c
 		}
-		result[collector.Name()] = c
 	}
 
 	result["gohai"] = versionMap()
@@ -87,8 +99,41 @@ func versionString() string {
 	return buf.String()
 }
 
+// Implement the flag.Value interface
+func (sc *SelectedCollectors) String() string {
+	collectorSlice := make([]string, 0)
+	for collectorName, _ := range *sc {
+		collectorSlice = append(collectorSlice, collectorName)
+	}
+	return fmt.Sprint(collectorSlice)
+}
+
+func (sc *SelectedCollectors) Set(value string) error {
+	for _, collectorName := range strings.Split(value, ",") {
+		(*sc)[collectorName] = true
+	}
+	return nil
+}
+
+// Return whether we should collect on a given collector, depending on the parsed flags
+func shouldCollect(collector Collector) bool {
+	if _, ok := options.only[collector.Name()]; len(options.only) > 0 && !ok {
+		return false
+	}
+
+	if _, ok := options.exclude[collector.Name()]; ok {
+		return false
+	}
+
+	return true
+}
+
+// Will be called after all the imported packages' init() have been called
+// Define collector-specific flags in their packages' init() function
 func init() {
 	flag.BoolVar(&options.version, "version", false, "Show version information and exit")
+	flag.Var(&options.only, "only", "Run only the listed collectors (comma-separated list of collector names)")
+	flag.Var(&options.exclude, "exclude", "Run all the collectors except those listed (comma-separated list of collector names)")
 	flag.Parse()
 }
 

--- a/gohai.go
+++ b/gohai.go
@@ -33,13 +33,10 @@ var collectors = []Collector{
 	&processes.Processes{},
 }
 
-var options = struct {
+var options struct {
 	only    SelectedCollectors
 	exclude SelectedCollectors
 	version bool
-}{
-	only:    make(SelectedCollectors),
-	exclude: make(SelectedCollectors),
 }
 
 // version information filled in at build time
@@ -131,6 +128,9 @@ func shouldCollect(collector Collector) bool {
 // Will be called after all the imported packages' init() have been called
 // Define collector-specific flags in their packages' init() function
 func init() {
+	options.only = make(SelectedCollectors)
+	options.exclude = make(SelectedCollectors)
+
 	flag.BoolVar(&options.version, "version", false, "Show version information and exit")
 	flag.Var(&options.only, "only", "Run only the listed collectors (comma-separated list of collector names)")
 	flag.Var(&options.exclude, "exclude", "Run all the collectors except those listed (comma-separated list of collector names)")

--- a/gohai.go
+++ b/gohai.go
@@ -22,7 +22,7 @@ type Collector interface {
 	Collect() (interface{}, error)
 }
 
-type SelectedCollectors map[string]bool
+type SelectedCollectors map[string]struct{}
 
 var collectors = []Collector{
 	&cpu.Cpu{},
@@ -110,7 +110,7 @@ func (sc *SelectedCollectors) String() string {
 
 func (sc *SelectedCollectors) Set(value string) error {
 	for _, collectorName := range strings.Split(value, ",") {
-		(*sc)[collectorName] = true
+		(*sc)[collectorName] = struct{}{}
 	}
 	return nil
 }

--- a/processes/gops/gops.go
+++ b/processes/gops/gops.go
@@ -1,0 +1,27 @@
+package gops
+
+import (
+	"sort"
+)
+
+func minInt(x, y int) int {
+	if x < y {
+		return x
+	}
+
+	return y
+}
+
+// Return an ordered slice of the process groups that use the most RSS
+func TopRSSProcessGroups(limit int) (ProcessNameGroups, error) {
+	procs, err := GetProcesses()
+	if err != nil {
+		return nil, err
+	}
+
+	procGroups := ByRSSDesc{GroupByName(procs)}
+
+	sort.Sort(procGroups)
+
+	return procGroups.ProcessNameGroups[:minInt(limit, len(procGroups.ProcessNameGroups))], nil
+}

--- a/processes/gops/process_group.go
+++ b/processes/gops/process_group.go
@@ -1,0 +1,101 @@
+package gops
+
+import (
+	"sort"
+)
+
+// Represents a group of processes, grouped by name
+type ProcessNameGroup struct {
+	pids      []int32
+	rss       uint64
+	pctMem    float64
+	vms       uint64
+	name      string
+	usernames map[string]bool
+}
+
+type ProcessNameGroups []*ProcessNameGroup
+
+func (pg *ProcessNameGroup) Pids() []int32 {
+	return pg.pids
+}
+
+func (pg *ProcessNameGroup) Name() string {
+	return pg.name
+}
+
+func (pg *ProcessNameGroup) RSS() uint64 {
+	return pg.rss
+}
+
+func (pg *ProcessNameGroup) PctMem() float64 {
+	return pg.pctMem
+}
+
+func (pg *ProcessNameGroup) VMS() uint64 {
+	return pg.vms
+}
+
+// Return a slice of the usernames, sorted alphabetically
+func (pg *ProcessNameGroup) Usernames() []string {
+	var usernameStringSlice sort.StringSlice
+	for username, _ := range pg.usernames {
+		usernameStringSlice = append(usernameStringSlice, username)
+	}
+
+	sort.Sort(usernameStringSlice)
+
+	return []string(usernameStringSlice)
+}
+
+func NewProcessNameGroup() *ProcessNameGroup {
+	processNameGroup := new(ProcessNameGroup)
+	processNameGroup.usernames = make(map[string]bool)
+
+	return processNameGroup
+}
+
+// Group the processInfos by name and return a slice of ProcessNameGroup
+func GroupByName(processInfos []*ProcessInfo) ProcessNameGroups {
+	groupIndexByName := make(map[string]int)
+	processNameGroups := make(ProcessNameGroups, 0, 10)
+
+	for _, processInfo := range processInfos {
+		if _, ok := groupIndexByName[processInfo.Name]; !ok {
+			processNameGroups = append(processNameGroups, NewProcessNameGroup())
+			groupIndexByName[processInfo.Name] = len(processNameGroups) - 1
+		}
+
+		processNameGroups[groupIndexByName[processInfo.Name]].add(processInfo)
+	}
+
+	return processNameGroups
+}
+
+func (pg *ProcessNameGroup) add(p *ProcessInfo) {
+	pg.pids = append(pg.pids, p.PID)
+	if pg.name == "" {
+		pg.name = p.Name
+	}
+	pg.rss += p.RSS
+	pg.pctMem += p.PctMem
+	pg.vms += p.VMS
+	pg.usernames[p.Username] = true
+}
+
+// Sort slices of process groups
+func (s ProcessNameGroups) Len() int {
+	return len(s)
+}
+
+func (s ProcessNameGroups) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type ByRSSDesc struct {
+	ProcessNameGroups
+}
+
+func (s ByRSSDesc) Less(i, j int) bool {
+	return s.ProcessNameGroups[i].RSS() > s.ProcessNameGroups[j].RSS()
+}

--- a/processes/gops/process_info.go
+++ b/processes/gops/process_info.go
@@ -1,0 +1,76 @@
+// Extract the information on running processes from gopsutil
+package gops
+
+import (
+	"log"
+
+	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/process"
+)
+
+type ProcessInfo struct {
+	PID      int32
+	Name     string
+	RSS      uint64
+	PctMem   float64
+	VMS      uint64
+	Username string
+}
+
+// Return a slice of all the processes that are running
+func GetProcesses() ([]*ProcessInfo, error) {
+	processInfos := make([]*ProcessInfo, 0, 10)
+
+	virtMemStat, err := mem.VirtualMemory()
+	if err != nil {
+		log.Printf("Error fetching system memory stats: %s", err)
+		return nil, err
+	}
+	totalMem := float64(virtMemStat.Total)
+
+	pids, err := process.Pids()
+	if err != nil {
+		log.Printf("Error fetching PIDs: %s", err)
+		return nil, err
+	}
+
+	for _, pid := range pids {
+		p, err := process.NewProcess(pid)
+		if err != nil {
+			log.Printf("Error fetching info for pid %d: %s", pid, err)
+			continue
+		}
+
+		processInfo, err := newProcessInfo(p, pid, totalMem)
+		if err != nil {
+			log.Printf("Error fetching info for pid %d: %s", pid, err)
+			continue
+		}
+
+		processInfos = append(processInfos, processInfo)
+	}
+
+	return processInfos, nil
+}
+
+// Make a new ProcessInfo from a Process from gopsutil
+func newProcessInfo(p *process.Process, pid int32, totalMem float64) (*ProcessInfo, error) {
+	memInfo, err := p.MemoryInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	name, err := pickName(p)
+	if err != nil {
+		return nil, err
+	}
+
+	pctMem := 100. * float64(memInfo.RSS) / totalMem
+
+	username, err := p.Username()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ProcessInfo{pid, name, memInfo.RSS, pctMem, memInfo.VMS, username}, nil
+}

--- a/processes/gops/process_info.go
+++ b/processes/gops/process_info.go
@@ -10,6 +10,7 @@ import (
 
 type ProcessInfo struct {
 	PID      int32
+	PPID     int32
 	Name     string
 	RSS      uint64
 	PctMem   float64
@@ -50,6 +51,9 @@ func GetProcesses() ([]*ProcessInfo, error) {
 		processInfos = append(processInfos, processInfo)
 	}
 
+	// platform-specific post-processing on the collected info
+	postProcess(processInfos)
+
 	return processInfos, nil
 }
 
@@ -60,7 +64,12 @@ func newProcessInfo(p *process.Process, pid int32, totalMem float64) (*ProcessIn
 		return nil, err
 	}
 
-	name, err := pickName(p)
+	ppid, err := p.Ppid()
+	if err != nil {
+		return nil, err
+	}
+
+	name, err := p.Name()
 	if err != nil {
 		return nil, err
 	}
@@ -72,5 +81,5 @@ func newProcessInfo(p *process.Process, pid int32, totalMem float64) (*ProcessIn
 		return nil, err
 	}
 
-	return &ProcessInfo{pid, name, memInfo.RSS, pctMem, memInfo.VMS, username}, nil
+	return &ProcessInfo{pid, ppid, name, memInfo.RSS, pctMem, memInfo.VMS, username}, nil
 }

--- a/processes/gops/process_info_darwin.go
+++ b/processes/gops/process_info_darwin.go
@@ -1,9 +1,4 @@
 package gops
 
-import (
-	"github.com/shirou/gopsutil/process"
-)
-
-func pickName(p *process.Process) (string, error) {
-	return p.Name()
-}
+// Do nothing for now
+func postProcess(processInfos []*ProcessInfo) {}

--- a/processes/gops/process_info_darwin.go
+++ b/processes/gops/process_info_darwin.go
@@ -1,0 +1,9 @@
+package gops
+
+import (
+	"github.com/shirou/gopsutil/process"
+)
+
+func pickName(p *process.Process) (string, error) {
+	return p.Name()
+}

--- a/processes/gops/process_info_linux.go
+++ b/processes/gops/process_info_linux.go
@@ -1,0 +1,20 @@
+package gops
+
+import (
+	"strings"
+
+	"github.com/shirou/gopsutil/process"
+)
+
+func pickName(p *process.Process) (string, error) {
+	cmdline, err := p.Cmdline()
+	if err != nil {
+		return "", err
+	}
+	// Assume that the process is a kernel process when it has no args
+	if strings.TrimSpace(cmdline) == "" {
+		return "kernel", nil
+	}
+
+	return p.Name()
+}

--- a/processes/gops/process_info_linux.go
+++ b/processes/gops/process_info_linux.go
@@ -1,20 +1,40 @@
 package gops
 
 import (
-	"strings"
+	"fmt"
 
 	"github.com/shirou/gopsutil/process"
 )
 
-func pickName(p *process.Process) (string, error) {
-	cmdline, err := p.Cmdline()
-	if err != nil {
-		return "", err
+// Build a hash pid -> ppid
+func buildPIDHash(processInfos []*ProcessInfo) (hash map[int32]int32) {
+	hash = make(map[int32]int32)
+	for _, processInfo := range processInfos {
+		hash[processInfo.PID] = processInfo.PPID
 	}
-	// Assume that the process is a kernel process when it has no args
-	if strings.TrimSpace(cmdline) == "" {
-		return "kernel", nil
+	return
+}
+
+// Return whether the PID is of a kernel thread, based on whether it has
+// the init process (PID 1) as ancestor
+func isKernelThread(pid int32, pidHash map[int32]int32) bool {
+	if pid == 1 {
+		return false
+	}
+	ppid, ok := pidHash[pid]
+	if !ok {
+		return true
 	}
 
-	return p.Name()
+	return isKernelThread(ppid, pidHash)
+}
+
+// Name processes "kernel" if they're a kernel thread
+func postProcess(processInfos []*ProcessInfo) {
+	pidHash := buildPIDHash(processInfos)
+	for _, processInfo := range processInfos {
+		if isKernelThread(processInfo.PID, pidHash) {
+			processInfo.Name = "kernel"
+		}
+	}
 }

--- a/processes/gops/process_info_linux.go
+++ b/processes/gops/process_info_linux.go
@@ -1,11 +1,5 @@
 package gops
 
-import (
-	"fmt"
-
-	"github.com/shirou/gopsutil/process"
-)
-
 // Build a hash pid -> ppid
 func buildPIDHash(processInfos []*ProcessInfo) (hash map[int32]int32) {
 	hash = make(map[int32]int32)
@@ -17,23 +11,30 @@ func buildPIDHash(processInfos []*ProcessInfo) (hash map[int32]int32) {
 
 // Return whether the PID is of a kernel thread, based on whether it has
 // the init process (PID 1) as ancestor
-func isKernelThread(pid int32, pidHash map[int32]int32) bool {
+func isKernelThread(pid int32, pidHash map[int32]int32, depth int32) bool {
 	if pid == 1 {
 		return false
 	}
+	// Once we reach this level of recursion we know it's not a kernel thread.
+	// Also, avoids a possible infinite recursion as our process list is not
+	// necessarily consistent.
+	if depth > 2 {
+		return false
+	}
+
 	ppid, ok := pidHash[pid]
 	if !ok {
 		return true
 	}
 
-	return isKernelThread(ppid, pidHash)
+	return isKernelThread(ppid, pidHash, depth+1)
 }
 
 // Name processes "kernel" if they're a kernel thread
 func postProcess(processInfos []*ProcessInfo) {
 	pidHash := buildPIDHash(processInfos)
 	for _, processInfo := range processInfos {
-		if isKernelThread(processInfo.PID, pidHash) {
+		if isKernelThread(processInfo.PID, pidHash, 0) {
 			processInfo.Name = "kernel"
 		}
 	}

--- a/processes/processes.go
+++ b/processes/processes.go
@@ -1,0 +1,57 @@
+package processes
+
+import (
+	"flag"
+	"strings"
+	"time"
+
+	"github.com/DataDog/gohai/processes/gops"
+)
+
+var options struct {
+	limit int
+}
+
+type ProcessField [7]interface{}
+
+type Processes struct{}
+
+const name = "processes"
+
+func init() {
+	flag.IntVar(&options.limit, name+"-limit", 20, "Number of process groups to return")
+}
+
+func (self *Processes) Name() string {
+	return name
+}
+
+func (self *Processes) Collect() (result interface{}, err error) {
+	result, err = getProcesses(options.limit)
+	return
+}
+
+// Return a JSON payload that's compatible with the legacy "processes" resource check
+func getProcesses(limit int) ([]interface{}, error) {
+	processGroups, err := gops.TopRSSProcessGroups(limit)
+	if err != nil {
+		return nil, err
+	}
+
+	snapData := make([]ProcessField, len(processGroups))
+
+	for i, processGroup := range processGroups {
+		processField := ProcessField{
+			strings.Join(processGroup.Usernames(), ","),
+			0, // pct_cpu, requires two consecutive samples to be computed, so not fetched for now
+			processGroup.PctMem(),
+			processGroup.VMS(),
+			processGroup.RSS(),
+			processGroup.Name(),
+			len(processGroup.Pids()),
+		}
+		snapData[i] = processField
+	}
+
+	return []interface{}{time.Now().Unix(), snapData}, nil
+}


### PR DESCRIPTION
- New collector to retrieve info on the top processes running, in a format
that is compatible with the legacy `processes` check of the agent.
Supports Linux and OS X for now.
- Flags to select/exclude the collectors to run