### PR TITLE
[cpu] Logical processors in windows output

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -12,6 +12,7 @@ var cpuMap = map[string]string{
 	"machdep.cpu.vendor":       "vendor_id",
 	"machdep.cpu.brand_string": "model_name",
 	"hw.physicalcpu":           "cpu_cores",
+	"hw.logicalcpu":            "cpu_logical_processors",
 	"hw.cpufrequency":          "mhz",
 	"machdep.cpu.family":       "family",
 	"machdep.cpu.model":        "model",


### PR DESCRIPTION
Forgot to add `cpu_logical_processors` to the output for windows.