### PR TITLE
[processes] Fix build on win32, return error at run time

### DIFF
--- a/processes/processes.go
+++ b/processes/processes.go
@@ -1,35 +1,15 @@
+// +build linux darwin
+
 package processes
 
 import (
-	"flag"
 	"strings"
 	"time"
 
 	"github.com/DataDog/gohai/processes/gops"
 )
 
-var options struct {
-	limit int
-}
-
 type ProcessField [7]interface{}
-
-type Processes struct{}
-
-const name = "processes"
-
-func init() {
-	flag.IntVar(&options.limit, name+"-limit", 20, "Number of process groups to return")
-}
-
-func (self *Processes) Name() string {
-	return name
-}
-
-func (self *Processes) Collect() (result interface{}, err error) {
-	result, err = getProcesses(options.limit)
-	return
-}
 
 // Return a JSON payload that's compatible with the legacy "processes" resource check
 func getProcesses(limit int) ([]interface{}, error) {

--- a/processes/processes_common.go
+++ b/processes/processes_common.go
@@ -1,0 +1,24 @@
+package processes
+
+import "flag"
+
+var options struct {
+	limit int
+}
+
+type Processes struct{}
+
+const name = "processes"
+
+func init() {
+	flag.IntVar(&options.limit, name+"-limit", 20, "Number of process groups to return")
+}
+
+func (self *Processes) Name() string {
+	return name
+}
+
+func (self *Processes) Collect() (result interface{}, err error) {
+	result, err = getProcesses(options.limit)
+	return
+}

--- a/processes/processes_windows.go
+++ b/processes/processes_windows.go
@@ -1,0 +1,7 @@
+package processes
+
+import "errors"
+
+func getProcesses(limit int) ([]interface{}, error) {
+	return nil, errors.New("Not implemented on Windows")
+}


### PR DESCRIPTION
The process collector is not compatible with Windows (yet), but gohai should still build and run fine.

This fixes the build and makes this collector return an error on Windows.