### PR TITLE
[processes] Ignore error when creating gopsutil process struct

### DIFF
--- a/processes/gops/process_info.go
+++ b/processes/gops/process_info.go
@@ -38,7 +38,8 @@ func GetProcesses() ([]*ProcessInfo, error) {
 	for _, pid := range pids {
 		p, err := process.NewProcess(pid)
 		if err != nil {
-			log.Printf("Error fetching info for pid %d: %s", pid, err)
+			// an error can occur here only if the process has disappeared,
+			// so we can safely ignore the error and skip the process
 			continue
 		}
 


### PR DESCRIPTION
To avoid useless and confusing log lines that would end up in the agent's collector logs too.

(For reference see https://github.com/shirou/gopsutil/blob/v2.0.0/process/process_linux.go#L65-L76 for the underlying implementation of `NewProcess` that justifies silencing the error)