### PR TITLE
[log] Use the seelog lib, support log levels

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	log "github.com/cihub/seelog"
+)
+
+const baseStdErrLogConfig = `<seelog minlevel="loglevel">
+	<outputs formatid="common">
+		<custom name="stderr" />
+	</outputs>
+	<formats>
+		<format id="common" format="%Msg%n"/>
+	</formats>
+</seelog>`
+
+type StdErrReceiver struct{}
+
+// Implement seelog.CustomReceiver to log to stderr instead of stdout
+func (sr *StdErrReceiver) ReceiveMessage(message string, level log.LogLevel, context log.LogContextInterface) error {
+	fmt.Fprintf(os.Stderr, message)
+	return nil
+}
+
+func (sr *StdErrReceiver) AfterParse(initArgs log.CustomReceiverInitArgs) error {
+	return nil
+}
+
+func (sr *StdErrReceiver) Flush() {}
+
+func (sr *StdErrReceiver) Close() error {
+	return nil
+}
+
+func initLogging(logLevel string) error {
+	log.RegisterReceiver("stderr", &StdErrReceiver{})
+
+	logConfig := bytes.Replace([]byte(baseStdErrLogConfig), []byte("loglevel"), []byte(logLevel), 1)
+	logger, err := log.LoggerFromConfigAsBytes(logConfig)
+	if err != nil {
+		return err
+	}
+
+	log.ReplaceLogger(logger)
+
+	return nil
+}

--- a/make.go
+++ b/make.go
@@ -36,7 +36,7 @@ func main() {
 	// For reference see https://github.com/golang/go/issues/12338
 	ldflags := fmt.Sprintf("-X main.buildDate '%s' -X main.gitCommit '%s' -X main.gitBranch '%s' -X main.goVersion '%s'", date, commit, branch, go_version)
 
-	cmd := exec.Command(gobin, "build", "-a", "-ldflags", ldflags, "gohai.go")
+	cmd := exec.Command(gobin, []string{"build", "-a", "-ldflags", ldflags}...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/processes/gops/process_info.go
+++ b/processes/gops/process_info.go
@@ -2,8 +2,12 @@
 package gops
 
 import (
-	"log"
+	"fmt"
 
+	// 3p
+	log "github.com/cihub/seelog"
+
+	// project
 	"github.com/shirou/gopsutil/mem"
 	"github.com/shirou/gopsutil/process"
 )
@@ -24,27 +28,28 @@ func GetProcesses() ([]*ProcessInfo, error) {
 
 	virtMemStat, err := mem.VirtualMemory()
 	if err != nil {
-		log.Printf("Error fetching system memory stats: %s", err)
+		err = fmt.Errorf("Error fetching system memory stats: %s", err)
 		return nil, err
 	}
 	totalMem := float64(virtMemStat.Total)
 
 	pids, err := process.Pids()
 	if err != nil {
-		log.Printf("Error fetching PIDs: %s", err)
+		err = fmt.Errorf("Error fetching PIDs: %s", err)
 		return nil, err
 	}
 
 	for _, pid := range pids {
 		p, err := process.NewProcess(pid)
 		if err != nil {
-			log.Printf("Error fetching info for pid %d: %s", pid, err)
+			// an error can occur here only if the process has disappeared,
+			log.Debugf("Process with pid %d disappeared while scanning: %s", pid, err)
 			continue
 		}
 
 		processInfo, err := newProcessInfo(p, pid, totalMem)
 		if err != nil {
-			log.Printf("Error fetching info for pid %d: %s", pid, err)
+			log.Infof("Error fetching info for pid %d: %s", pid, err)
 			continue
 		}
 


### PR DESCRIPTION
The log level can be specified through the `log-level` cli option
(default: `info`)

Also, makes the `make.go` script support building multiple files.

Supersedes https://github.com/DataDog/gohai/pull/29

**NB**: this requires adding the seelog lib to gohai's software definition in omnibus-software