### PR TITLE
Check number of lines of response.  Using same algorithm as Linux,

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -1,34 +1,33 @@
 package cpu
 
 import (
-	utils "github.com/DataDog/gohai/windowsutils"
-	// "strconv"
 	"fmt"
+	utils "github.com/DataDog/gohai/windowsutils"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
-var cpuMap = map[string]string{
-	"machdep.cpu.vendor":       "vendor_id",
-	"machdep.cpu.brand_string": "model_name",
-	"hw.physicalcpu":           "cpu_cores",
-	"hw.logicalcpu":            "cpu_logical_processors",
-	"hw.cpufrequency":          "mhz",
-	"machdep.cpu.family":       "family",
-	"machdep.cpu.model":        "model",
-	"machdep.cpu.stepping":     "stepping",
+// Values that need to be multiplied by the number of physical processors
+var perPhysicalProcValues = []string{
+	"cpu_cores",
+	"cpu_logical_processors",
 }
 
 func getCpuInfo() (cpuInfo map[string]string, err error) {
 
 	cpuInfo = make(map[string]string)
 
-	cpu, err := utils.WindowsWMICommand("CPU",
+	cpus, err := utils.WindowsWMIMultilineCommand("CPU",
 		"CurrentClockSpeed", "Name", "NumberOfCores",
 		"NumberOfLogicalProcessors", "Caption", "Manufacturer")
 	if err != nil {
 		return
 	}
+	// each line represents a different CPUx
+	numberOfPhysicalCpus := len(cpus)
+	cpu := cpus[0]
+
 	cpuInfo["mhz"] = cpu["CurrentClockSpeed"]
 	cpuInfo["model_name"] = cpu["Name"]
 	cpuInfo["cpu_cores"] = cpu["NumberOfCores"]
@@ -39,6 +38,18 @@ func getCpuInfo() (cpuInfo map[string]string, err error) {
 	cpuInfo["family"] = extract(caption, "Family")
 	cpuInfo["model"] = extract(caption, "Model")
 	cpuInfo["stepping"] = extract(caption, "Stepping")
+
+	// Multiply the values that are "per physical processor" by the number of physical procs
+	for _, field := range perPhysicalProcValues {
+		if value, ok := cpuInfo[field]; ok {
+			intValue, err := strconv.Atoi(value)
+			if err != nil {
+				continue
+			}
+
+			cpuInfo[field] = strconv.Itoa(intValue * numberOfPhysicalCpus)
+		}
+	}
 
 	return
 }


### PR DESCRIPTION
multiply number of cores and virtual processors (HT) by nummber of
responses.

Fixes card [gohai] Windows: report correct number of CPUs on multi-socket
hosts


What does this PR do?

Takes into account the number of physical CPUs when reporting cores/hyperthreading threads. Was always reporting values from a single CPU.

Motivation

Bug reported by customer

Testing Guidelines

An overview on testing
is available in our contribution guidelines.

Additional Notes

Was tested with VMWare workstation emulating two physical CPUs.