### PR TITLE
Go >=1.5 syntax for ldflags

### DIFF
--- a/make.go
+++ b/make.go
@@ -32,9 +32,7 @@ func main() {
 	branch := commandOutput("git", "rev-parse", "--abbrev-ref", "HEAD")
 	go_version := commandOutput(gobin, "version")
 
-	// NB: Starting from Go 1.5, the syntax of these ldflags changes from `-X main.var 'value'` to `-X 'main.var=value'`
-	// For reference see https://github.com/golang/go/issues/12338
-	ldflags := fmt.Sprintf("-X main.buildDate '%s' -X main.gitCommit '%s' -X main.gitBranch '%s' -X main.goVersion '%s'", date, commit, branch, go_version)
+	ldflags := fmt.Sprintf("-X 'main.buildDate=%s' -X main.gitCommit=%s -X main.gitBranch=%s -X 'main.goVersion=%s'", date, commit, branch, go_version)
 
 	cmd := exec.Command(gobin, []string{"build", "-a", "-ldflags", ldflags}...)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Tested it wi th Go 1.7.4 on Mac, it works fine. `'` are needed when the arg has space in it. The entire arg needs to be quoted when containing space: `-X 'main.flag=arg with space'` .
https://www.timeanddate.com/countdown/generic?iso=20170331T00&p0=179&msg=Centos/RHEL+5+End+of+life&font=cursive