### PR TITLE
[Windows Gohai] Allow for more complete partial returns.

### DIFF
--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -23,17 +23,17 @@ func getCpuInfo() (cpuInfo map[string]string, err error) {
 
 	for option, key := range cpuMap {
 		out, err := exec.Command("sysctl", "-n", option).Output()
-		if err != nil {
-			return cpuInfo, err
+		if err == nil {
+			cpuInfo[key] = strings.Trim(string(out), "\n")
 		}
-		cpuInfo[key] = strings.Trim(string(out), "\n")
 	}
 
-	mhz, err := strconv.Atoi(cpuInfo["mhz"])
-	if err != nil {
-		return cpuInfo, err
+	if cpuInfo["mhz"] {
+		mhz, err := strconv.Atoi(cpuInfo["mhz"])
+		if err == nil {
+			cpuInfo["mhz"] = strconv.Itoa(mhz / 1000000)
+		}
 	}
-	cpuInfo["mhz"] = strconv.Itoa(mhz / 1000000)
 
 	return
 }

--- a/cpu/cpu_darwin.go
+++ b/cpu/cpu_darwin.go
@@ -28,7 +28,7 @@ func getCpuInfo() (cpuInfo map[string]string, err error) {
 		}
 	}
 
-	if cpuInfo["mhz"] {
+	if len(cpuInfo["mhz"]) != 0 {
 		mhz, err := strconv.Atoi(cpuInfo["mhz"])
 		if err == nil {
 			cpuInfo["mhz"] = strconv.Itoa(mhz / 1000000)

--- a/gohai.go
+++ b/gohai.go
@@ -59,9 +59,10 @@ func Collect() (result map[string]interface{}, err error) {
 			c, err := collector.Collect()
 			if err != nil {
 				log.Warnf("[%s] %s", collector.Name(), err)
-				continue
 			}
-			result[collector.Name()] = c
+			if c != nil {
+				result[collector.Name()] = c
+			}
 		}
 	}
 

--- a/memory/memory_darwin.go
+++ b/memory/memory_darwin.go
@@ -10,17 +10,15 @@ func getMemoryInfo() (memoryInfo map[string]string, err error) {
 	memoryInfo = make(map[string]string)
 
 	out, err := exec.Command("sysctl", "-n", "hw.memsize").Output()
-	if err != nil {
-		return memoryInfo, err
+	if err == nil {
+		memoryInfo["total"] = strings.Trim(string(out), "\n")
 	}
-	memoryInfo["total"] = strings.Trim(string(out), "\n")
 
 	out, err = exec.Command("sysctl", "-n", "vm.swapusage").Output()
-	if err != nil {
-		return memoryInfo, err
+	if err == nil {
+		swap := regexp.MustCompile("total = ").Split(string(out), 2)[1]
+		memoryInfo["swap_total"] = strings.Split(swap, " ")[0]
 	}
-	swap := regexp.MustCompile("total = ").Split(string(out), 2)[1]
-	memoryInfo["swap_total"] = strings.Split(swap, " ")[0]
 
 	return
 }

--- a/platform/platform_common.go
+++ b/platform/platform_common.go
@@ -23,17 +23,22 @@ func (self *Platform) Collect() (result interface{}, err error) {
 
 func getPlatformInfo() (platformInfo map[string]interface{}, err error) {
 
+	// collect each portion, and allow the parts that succeed (even if some
+	// parts fail.)  For this check, it does have the (small) liability
+	// that if both the ArchInfo() and the PythonVersion() fail, the error
+	// from the ArchInfo() will be lost
+
+	// for this, no error check.  The successful results will be added
+	// to the return value, and the error stored.
 	platformInfo, err = getArchInfo()
-	if err != nil {
-		return platformInfo, err
-	}
 
 	platformInfo["goV"] = strings.Replace(runtime.Version(), "go", "", -1)
 	pythonV, err := getPythonVersion()
-	if err != nil {
-		return platformInfo, err
+
+	// if there was no failure, add the python variables to the platformInfo
+	if err == nil {
+		platformInfo["pythonV"] = pythonV
 	}
-	platformInfo["pythonV"] = pythonV
 
 	platformInfo["GOOS"] = runtime.GOOS
 	platformInfo["GOOARCH"] = runtime.GOARCH

--- a/processes/processes_common.go
+++ b/processes/processes_common.go
@@ -19,6 +19,14 @@ func (self *Processes) Name() string {
 }
 
 func (self *Processes) Collect() (result interface{}, err error) {
-	result, err = getProcesses(options.limit)
-	return
+	// even if getProcesses returns nil, simply assigning to result
+	// will have a non-nil return, because it has a valid inner
+	// type (more info here: https://golang.org/doc/faq#nil_error )
+	// so, jump through the hoop of temporarily storing the return,
+	// and explicitly return nil if it fails.
+	gpresult, err := getProcesses(options.limit)
+	if gpresult == nil {
+		return nil, err
+	}
+	return gpresult, err
 }


### PR DESCRIPTION
The checks, specifically the platform check, has an early return if a
portion of the check fails.  This means that the remainder of the
(functional) check is skipped, and available information is missed.
Attempt to return as much information as possible, even if portions of the
check fail.