### PR TITLE
[Windows] Enable process metadata on windows.  Needs associated change

### DIFF
--- a/processes/gops/process_info_windows.go
+++ b/processes/gops/process_info_windows.go
@@ -1,0 +1,4 @@
+package gops
+
+// Do nothing for now
+func postProcess(processInfos []*ProcessInfo) {}

--- a/processes/processes.go
+++ b/processes/processes.go
@@ -1,5 +1,3 @@
-// +build linux darwin
-
 package processes
 
 import (

--- a/processes/processes_windows.go
+++ b/processes/processes_windows.go
@@ -1,7 +1,0 @@
-package processes
-
-import "errors"
-
-func getProcesses(limit int) ([]interface{}, error) {
-	return nil, errors.New("Not implemented on Windows")
-}


### PR DESCRIPTION
from shirou/gopsutil.

Change for agent6, to enable process metadata.  Associated change for gopsutil has been submitted to that package's owner.  