### PR TITLE
[platform] Fix nil map dereference

### DIFF
--- a/platform/platform_common.go
+++ b/platform/platform_common.go
@@ -30,6 +30,7 @@ func getPlatformInfo() (platformInfo map[string]interface{}, err error) {
 	// that if both the ArchInfo() and the PythonVersion() fail, the error
 	// from the ArchInfo() will be lost
 
+	platformInfo = make(map[string]interface{})
 	// for this, no error check.  The successful results will be added
 	// to the return value, and the error stored.
 	platformInfo, err = GetArchInfo()


### PR DESCRIPTION
Was present since the beginning of the project. Could happen when the
`uname` command returned an error, which may explain why we've only
noticed this recently.

Also did a cursory check on the rest of the project for similar nil dereferences,
didn't find any other.