### PR TITLE
fix filesystem info command timeout logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Gohai is a tool which collects an inventory of system information. It aims to im
 
 ## Usage
 
-Gohai will build and install with `go get`. We require at least Go 1.5.
+Gohai will build and install with `go get`. We require at least Go 1.7.
 
 ```sh
 go get github.com/DataDog/gohai

--- a/filesystem/filesystem_test.go
+++ b/filesystem/filesystem_test.go
@@ -1,8 +1,8 @@
 package filesystem
 
 import (
+	"context"
 	"fmt"
-	"log"
 	"os/exec"
 	"reflect"
 	"testing"
@@ -11,47 +11,20 @@ import (
 
 func MockSlowGetFileSystemInfo() (interface{}, error) {
 	/* Run a command that will definitely time out */
-	cmd := exec.Command("sleep", "5")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
-	outCh := make(chan []byte, 1)
-	errCh := make(chan error, 1)
+	/* Grab filesystem data from df	*/
+	cmd := exec.CommandContext(ctx, "sleep", "5")
 
-	var out interface{}
-	var err error
-
-	go func() {
-		_out, _err := cmd.Output()
-		if _err != nil {
-			errCh <- fmt.Errorf("df failed to collect filesystem data: %s", _err)
-			return
-		}
-		outCh <- _out
-	}()
-
-WAIT:
-	for {
-		select {
-		case res := <-outCh:
-			if res != nil {
-				out, err = parseDfOutput(string(res))
-			} else {
-				out, err = nil, fmt.Errorf("df failed to collect filesystem data")
-			}
-			break WAIT
-		case err = <-errCh:
-			out = nil
-			break WAIT
-		case <-time.After(2 * time.Second):
-			// Kill the process if it takes too long
-			if killErr := cmd.Process.Kill(); killErr != nil {
-				log.Fatal("failed to kill:", killErr)
-				// Force goroutine to exit
-				<-outCh
-			}
-		}
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("df failed to collect filesystem data: %s", err)
 	}
-
-	return out, err
+	if out != nil {
+		return parseDfOutput(string(out))
+	}
+	return nil, fmt.Errorf("df failed to collect filesystem data")
 }
 
 func TestSlowGetFileSystemInfo(t *testing.T) {


### PR DESCRIPTION
This uses the exec.CommandContext function to handle the timeout properly

Issue was caused by a race condition, process could have exited or not being started when the timeout expired