### PR TITLE
collects network information from other Network Interfaces

### DIFF
--- a/network/network_common.go
+++ b/network/network_common.go
@@ -16,7 +16,7 @@ func (self *Network) Name() string {
 func (self *Network) Collect() (result interface{}, err error) {
 	result, err = getNetworkInfo()
 	interfaces := getMultiNetworkInfo()
-	if interfaces != nil {
+	if len(interfaces) > 0 {
 		interfaceMap, ok := result.(map[string]interface{})
 		if !ok {
 			return
@@ -63,10 +63,7 @@ func getMultiNetworkInfo() (multiNetworkInfo []map[string]interface{}) {
 			multiNetworkInfo = append(multiNetworkInfo, _iface)
 		}
 	}
-	if len(multiNetworkInfo) > 0 {
-		return multiNetworkInfo
-	}
-	return nil
+	return multiNetworkInfo
 }
 
 type Ipv6Address struct{}

--- a/network/network_common.go
+++ b/network/network_common.go
@@ -15,7 +15,8 @@ func (self *Network) Name() string {
 
 func (self *Network) Collect() (result interface{}, err error) {
 	result, err = getNetworkInfo()
-	interfaces := getMultiNetworkInfo()
+	interfaces, err2 := getMultiNetworkInfo()
+
 	if len(interfaces) > 0 {
 		interfaceMap, ok := result.(map[string]interface{})
 		if !ok {
@@ -23,14 +24,18 @@ func (self *Network) Collect() (result interface{}, err error) {
 		}
 		interfaceMap["interfaces"] = interfaces
 	}
+
+	if err == nil && err2 != nil {
+		err = err2
+	}
 	return
 }
 
-func getMultiNetworkInfo() (multiNetworkInfo []map[string]interface{}) {
+func getMultiNetworkInfo() (multiNetworkInfo []map[string]interface{}, err error) {
 	ifaces, err := net.Interfaces()
 
 	if err != nil {
-		return nil
+		return multiNetworkInfo, err
 	}
 	for _, iface := range ifaces {
 		_iface := make(map[string]interface{})
@@ -63,7 +68,7 @@ func getMultiNetworkInfo() (multiNetworkInfo []map[string]interface{}) {
 			multiNetworkInfo = append(multiNetworkInfo, _iface)
 		}
 	}
-	return multiNetworkInfo
+	return multiNetworkInfo, err
 }
 
 type Ipv6Address struct{}

--- a/network/network_common.go
+++ b/network/network_common.go
@@ -45,7 +45,8 @@ func getMultiNetworkInfo() (multiNetworkInfo []map[string]interface{}, err error
 		}
 		addrs, err := iface.Addrs()
 		if err != nil {
-			return nil
+			// skip this interface but try the next
+			continue
 		}
 		for _, addr := range addrs {
 			ip, network, _ := net.ParseCIDR(addr.String())

--- a/network/network_common.go
+++ b/network/network_common.go
@@ -15,18 +15,17 @@ func (self *Network) Name() string {
 
 func (self *Network) Collect() (result interface{}, err error) {
 	result, err = getNetworkInfo()
-	interfaces, err2 := getMultiNetworkInfo()
+	if err != nil {
+		return
+	}
 
-	if len(interfaces) > 0 {
+	interfaces, err := getMultiNetworkInfo()
+	if err == nil && len(interfaces) > 0 {
 		interfaceMap, ok := result.(map[string]interface{})
 		if !ok {
 			return
 		}
 		interfaceMap["interfaces"] = interfaces
-	}
-
-	if err == nil && err2 != nil {
-		err = err2
 	}
 	return
 }

--- a/network/network_common.go
+++ b/network/network_common.go
@@ -17,7 +17,11 @@ func (self *Network) Collect() (result interface{}, err error) {
 	result, err = getNetworkInfo()
 	interfaces := getMultiNetworkInfo()
 	if interfaces != nil {
-		result["interfaces"] = interfaces
+		interfaceMap, ok := result.(map[string]interface{})
+		if !ok {
+			return
+		}
+		interfaceMap["interfaces"] = interfaces
 	}
 	return
 }
@@ -28,8 +32,8 @@ func getMultiNetworkInfo() (multiNetworkInfo []map[string]interface{}) {
 	if err != nil {
 		return nil
 	}
-	_iface := make(map[string]interface{})
 	for _, iface := range ifaces {
+		_iface := make(map[string]interface{})
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
 			// interface down or loopback interface
 			continue


### PR DESCRIPTION
For backwards compatibility, information collected for other interfaces are in addition to what we already collect. See screenshot below.

https://cl.ly/d40b80942818

Caveats:

- Information can be only retrieved from the UI using the JSON permalink.
- Frontend code will have to be modified if we want to have this information displayed under the hosts's "System Information" section