### PR TITLE
Update things for recent Go versions

### DIFF
--- a/gohai.go
+++ b/gohai.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	// 3p
@@ -103,10 +104,11 @@ func versionString() string {
 
 // Implement the flag.Value interface
 func (sc *SelectedCollectors) String() string {
-	collectorSlice := make([]string, 0)
+	collectorSlice := make([]string, 0, len(*sc))
 	for collectorName := range *sc {
 		collectorSlice = append(collectorSlice, collectorName)
 	}
+	sort.Strings(collectorSlice)
 	return fmt.Sprint(collectorSlice)
 }
 

--- a/gohai.go
+++ b/gohai.go
@@ -140,11 +140,12 @@ func init() {
 	flag.Var(&options.only, "only", "Run only the listed collectors (comma-separated list of collector names)")
 	flag.Var(&options.exclude, "exclude", "Run all the collectors except those listed (comma-separated list of collector names)")
 	flag.StringVar(&options.logLevel, "log-level", "info", "Log level (one of 'warn', 'info', 'debug')")
-	flag.Parse()
 }
 
 func main() {
 	defer log.Flush()
+
+	flag.Parse()
 
 	err := initLogging(options.logLevel)
 	if err != nil {

--- a/gohai_test.go
+++ b/gohai_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSelectedCollectors_String(t *testing.T) {
@@ -10,5 +11,5 @@ func TestSelectedCollectors_String(t *testing.T) {
 		"foo": struct{}{},
 		"bar": struct{}{},
 	}
-	assert.Equal(t, "[foo bar]", sc.String())
+	assert.Equal(t, "[bar foo]", sc.String())
 }


### PR DESCRIPTION
This fixes a few minor bugs presumably uncovered in recent versions of Go.  See the commits for details.

If desired, I can also enable CircleCI for this repo.