### PR TITLE
Refactor Windows' GetArchInfo to support Windows 11 and later OS

### DIFF
--- a/platform/platform_windows.go
+++ b/platform/platform_windows.go
@@ -4,18 +4,37 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"syscall"
+	"unicode/utf16"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
 
+type OSVERSIONINFOEXW struct {
+	dwOSVersionInfoSize uint32
+	dwMajorVersion uint32
+	dwMinorVersion uint32
+	dwBuildNumber uint32
+	dwPlatformId uint32
+	szCSDVersion [128]uint16
+	wServicePackMajor uint16
+	wServicePackMinor uint16
+	wSuiteMask uint16
+	wProductType uint8
+	wReserved uint8
+}
+
 var (
-	modNetapi32          = windows.NewLazyDLL("Netapi32.dll")
-	procNetWkstaGetInfo  = modNetapi32.NewProc("NetWkstaGetInfo")
-	procNetServerGetInfo = modNetapi32.NewProc("NetServerGetInfo")
-	procNetApiBufferFree = modNetapi32.NewProc("NetApiBufferFree")
+	modNetapi32                = windows.NewLazyDLL("Netapi32.dll")
+	procNetServerGetInfo       = modNetapi32.NewProc("NetServerGetInfo")
+	procNetApiBufferFree       = modNetapi32.NewProc("NetApiBufferFree")
+	ntdll                      = windows.NewLazyDLL("Ntdll.dll")
+	procRtlGetVersion          = ntdll.NewProc("RtlGetVersion")
+	winbrand                   = windows.NewLazyDLL("winbrand.dll")
+	ERROR_SUCESS syscall.Errno = 0
 )
 
 const (
@@ -59,24 +78,6 @@ const buildNumberKey = "CurrentBuildNumber"
 const majorKey = "CurrentMajorVersionNumber"
 const minorKey = "CurrentMinorVersionNumber"
 
-func GetVersion() (maj uint64, min uint64, err error) {
-
-	var outdata *byte
-	if err = modNetapi32.Load(); err != nil {
-		return
-	}
-	if err = procNetWkstaGetInfo.Find(); err != nil {
-		return
-	}
-	status, _, err := procNetWkstaGetInfo.Call(uintptr(0), uintptr(100), uintptr(unsafe.Pointer(&outdata)))
-	if status != uintptr(0) {
-		return 0, 0, err
-	}
-	defer procNetApiBufferFree.Call(uintptr(unsafe.Pointer(outdata)))
-	return platGetVersion(outdata)
-
-}
-
 func netServerGetInfo() (si SERVER_INFO_101, err error) {
 	var outdata *byte
 	// do additional work so that we don't panic() when the library's
@@ -95,6 +96,62 @@ func netServerGetInfo() (si SERVER_INFO_101, err error) {
 	return platGetServerInfo(outdata), nil
 }
 
+func fetchOsDescription() (string, error) {
+	err := winbrand.Load()
+	if err == ERROR_SUCESS {
+		err = nil
+		procBrandingFormatString := winbrand.NewProc("BrandingFormatString")
+		if procBrandingFormatString.Find() != nil {
+			// Encode the string "%WINDOWS_LONG%" to UTF-16 and append a null byte for the Windows API
+			magicString := utf16.Encode([]rune("%WINDOWS_LONG%" + "\x00"))
+			os, _, err := procBrandingFormatString.Call(uintptr(unsafe.Pointer(&magicString[0])))
+			defer syscall.LocalFree(syscall.Handle(os))
+			if err == ERROR_SUCESS {
+				return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(os))), nil
+			}
+		}
+	} else {
+		k, err := registry.OpenKey(registry.LOCAL_MACHINE,
+			registryHive,
+			registry.QUERY_VALUE)
+		defer k.Close()
+		if err == nil {
+			os , _, _ := k.GetStringValue(productNameKey)
+			return os, nil
+		}
+	}
+	return "(undetermined windows version)", err
+}
+
+func fetchWindowsVersion() (uint64,uint64,uint64,error) {
+	var err error
+	var major uint64
+	var minor uint64
+	var build uint64
+
+	var osversion OSVERSIONINFOEXW
+	status, _, _ := procRtlGetVersion.Call(uintptr(unsafe.Pointer(&osversion)))
+	if status == 0 {
+		major = uint64(osversion.dwMajorVersion)
+		minor = uint64(osversion.dwMinorVersion)
+		build = uint64(osversion.dwBuildNumber)
+	} else {
+		k, err := registry.OpenKey(registry.LOCAL_MACHINE,
+			registryHive,
+			registry.QUERY_VALUE)
+		defer k.Close()
+		if err != nil {
+			var regmajor, _, _ = k.GetIntegerValue(majorKey)
+			var regminor, _, _ = k.GetIntegerValue(minorKey)
+			var regbuild, _, _ = k.GetStringValue(buildNumberKey)
+			major = regmajor
+			minor = regminor
+			build, _ = strconv.ParseUint(regbuild, 10, 0)
+		}
+	}
+	return major, minor, build, err
+}
+
 // GetArchInfo() returns basic host architecture information
 func GetArchInfo() (systemInfo map[string]interface{}, err error) {
 	systemInfo = make(map[string]interface{})
@@ -107,23 +164,10 @@ func GetArchInfo() (systemInfo map[string]interface{}, err error) {
 		systemInfo["machine"] = runtime.GOARCH
 	}
 
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
-		registryHive,
-		registry.QUERY_VALUE)
-	defer k.Close()
+	systemInfo["os"], err = fetchOsDescription()
 
-	systemInfo["os"], _, _ = k.GetStringValue(productNameKey)
-
-	var maj, _, _ = k.GetIntegerValue(majorKey)
-	var min, _, _ = k.GetIntegerValue(minorKey)
-	var bld, _, _ = k.GetStringValue(buildNumberKey)
-	if maj == 0 {
-		maj, min, err = GetVersion()
-		if 0 != syscall.Errno(0) {
-			return
-		}
-	}
-	verstring := fmt.Sprintf("%d.%d.%s", maj, min, bld)
+	maj, min, bld, err := fetchWindowsVersion()
+	verstring := fmt.Sprintf("%d.%d.%d", maj, min, bld)
 	systemInfo["kernel_release"] = verstring
 
 	systemInfo["kernel_name"] = "Windows"
@@ -154,15 +198,4 @@ func GetArchInfo() (systemInfo map[string]interface{}, err error) {
 	systemInfo["family"] = family
 
 	return
-}
-
-func convert_windows_string(winput []uint16) string {
-	var retstring string
-	for i := 0; i < len(winput); i++ {
-		if winput[i] == 0 {
-			break
-		}
-		retstring += string(rune(winput[i]))
-	}
-	return retstring
 }


### PR DESCRIPTION
This PR refactors `GetArchInfo` to support Windows 11 and later OSes.

[GetVersion ](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa) is a deprecated API so [RtlGetVersion ](https://docs.microsoft.com/en-us/windows/win32/devnotes/rtlgetversion) was used instead. `RtlGetVersion` has the added benefit of returning the build number as well. Should this function not return a correct value in the future, we fallback on the registry key like we did before.

For the OS description, the registry key is no longer updated. There is a function called `BrandingFormatString` from `winbrand.dll` which returns the correct OS description. If this DLL is found and this method is present, we use it, otherwise we fallback to the registry key like we did before.

Windows 11 Pro:
![image](https://user-images.githubusercontent.com/63521/142944988-9cebd292-7a67-4bd3-a43d-d6ef1982c2fd.png)

Windows server 2008 R2:
![image](https://user-images.githubusercontent.com/63521/142945035-189825f0-0f91-4af7-8318-c5c1560a6ac7.png)
