### PR TITLE
[platform] Fix potential panic when collecting python version

### DIFF
--- a/platform/platform_common.go
+++ b/platform/platform_common.go
@@ -61,5 +61,8 @@ func getPythonVersion() (string, error) {
 	}
 	version := fmt.Sprintf("%s", out)
 	values := regexp.MustCompile("Python (.*)\n").FindStringSubmatch(version)
+	if len(values) < 2 {
+		return "", fmt.Errorf("could not find Python version in `python -V` output: %q", version)
+	}
 	return strings.Trim(values[1], "\r"), nil
 }


### PR DESCRIPTION
A panic happened in a support case on the line `return strings.Trim(values[1], "\r"), nil` (`index out of range [1] with length 0`).

Although we were not able to get more information on the `python -V` output that caused this to happen, let's be safer in this code path.

This code path is not tested (I only tested that the command still works in the nominal case), I'm preparing a separate PR to add some tests and testing facilities in general.