### PR TITLE
Test Python version collection + add CI with Github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Test
+      run: go test ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,12 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: 1.17.x
     - name: Test
       run: go test ./...

--- a/filesystem/filesystem_nix_test.go
+++ b/filesystem/filesystem_nix_test.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package filesystem
 
 import (

--- a/platform/platform_common.go
+++ b/platform/platform_common.go
@@ -61,7 +61,11 @@ func getPythonVersion(execCmd utils.ExecCmdFunc) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	version := fmt.Sprintf("%s", out)
+	return parsePythonVersion(out)
+}
+
+func parsePythonVersion(cmdOut []byte) (string, error) {
+	version := fmt.Sprintf("%s", cmdOut)
 	values := regexp.MustCompile("Python (.*)\n").FindStringSubmatch(version)
 	if len(values) < 2 {
 		return "", fmt.Errorf("could not find Python version in `python -V` output: %q", version)

--- a/platform/platform_common.go
+++ b/platform/platform_common.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+
+	"github.com/DataDog/gohai/utils"
 )
 
 type Platform struct{}
@@ -41,7 +43,7 @@ func getPlatformInfo() (platformInfo map[string]interface{}, err error) {
 	// If this errors, swallow the error.
 	// It will usually mean that Python is not on the PATH
 	// and we don't care about that.
-	pythonV, e := getPythonVersion()
+	pythonV, e := getPythonVersion(exec.Command)
 
 	// if there was no failure, add the python variables to the platformInfo
 	if e == nil {
@@ -54,8 +56,8 @@ func getPlatformInfo() (platformInfo map[string]interface{}, err error) {
 	return
 }
 
-func getPythonVersion() (string, error) {
-	out, err := exec.Command("python", "-V").CombinedOutput()
+func getPythonVersion(execCmd utils.ExecCmdFunc) (string, error) {
+	out, err := execCmd("python", "-V").CombinedOutput()
 	if err != nil {
 		return "", err
 	}

--- a/platform/platform_common_test.go
+++ b/platform/platform_common_test.go
@@ -1,0 +1,72 @@
+package platform
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/gohai/utils"
+)
+
+func TestGetPythonVersion(t *testing.T) {
+	t.Run("valid Python version", func(t *testing.T) {
+		pythonV, err := getPythonVersion(pythonVersionFakeExecCmd("TestGetPythonVersionCmd", "valid"))
+		assert.Nil(t, err)
+		assert.Equal(t, "3.8.9", pythonV)
+	})
+
+	t.Run("valid Python version (windows)", func(t *testing.T) {
+		pythonV, err := getPythonVersion(pythonVersionFakeExecCmd("TestGetPythonVersionCmd", "valid-windows"))
+		assert.Nil(t, err)
+		assert.Equal(t, "3.8.9", pythonV)
+	})
+
+	t.Run("Python not present", func(t *testing.T) {
+		pythonV, err := getPythonVersion(pythonVersionFakeExecCmd("TestGetPythonVersionCmd", "not-present"))
+		assert.NotNil(t, err)
+		assert.Equal(t, "", pythonV)
+	})
+
+	t.Run("invalid Python version", func(t *testing.T) {
+		pythonV, err := getPythonVersion(pythonVersionFakeExecCmd("TestGetPythonVersionCmd", "invalid"))
+		assert.NotNil(t, err)
+		assert.Equal(t, "", pythonV)
+	})
+}
+
+// TestGetHostnameShellCmd is a method that is called as a substitute for a shell command,
+// the GO_TEST_PROCESS flag ensures that if it is called as part of the test suite, it is skipped.
+func TestGetPythonVersionCmd(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+
+	testRunName, cmdList := utils.ParseFakeExecCmdArgs()
+
+	assert.EqualValues(t, []string{"python", "-V"}, cmdList)
+
+	switch testRunName {
+	case "valid":
+		fmt.Fprintf(os.Stdout, "Python 3.8.9\n")
+		os.Exit(0)
+	case "valid-windows":
+		fmt.Fprintf(os.Stdout, "Python 3.8.9\r\n")
+		os.Exit(0)
+	case "not-present":
+		fmt.Fprintf(os.Stdout, "")
+		fmt.Fprintf(os.Stderr, "command not found: python")
+		os.Exit(127)
+	case "invalid":
+		fmt.Fprintf(os.Stdout, "giberrish")
+		os.Exit(0)
+	}
+}
+
+func pythonVersionFakeExecCmd(testName string, testRunName string) utils.ExecCmdFunc {
+	return func(command string, args ...string) *exec.Cmd {
+		return utils.FakeExecCmd(testName, testRunName, command, args...)
+	}
+}

--- a/platform/platform_common_test.go
+++ b/platform/platform_common_test.go
@@ -3,7 +3,6 @@ package platform
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,34 +10,43 @@ import (
 	"github.com/DataDog/gohai/utils"
 )
 
-func TestGetPythonVersion(t *testing.T) {
+func TestParsePythonVersion(t *testing.T) {
 	t.Run("valid Python version", func(t *testing.T) {
-		pythonV, err := getPythonVersion(pythonVersionFakeExecCmd("TestGetPythonVersionCmd", "valid"))
+		pythonV, err := parsePythonVersion([]byte("Python 3.8.9\n"))
 		assert.Nil(t, err)
 		assert.Equal(t, "3.8.9", pythonV)
 	})
 
 	t.Run("valid Python version (windows)", func(t *testing.T) {
-		pythonV, err := getPythonVersion(pythonVersionFakeExecCmd("TestGetPythonVersionCmd", "valid-windows"))
+		pythonV, err := parsePythonVersion([]byte("Python 3.8.9\r\n"))
 		assert.Nil(t, err)
 		assert.Equal(t, "3.8.9", pythonV)
 	})
 
-	t.Run("Python not present", func(t *testing.T) {
-		pythonV, err := getPythonVersion(pythonVersionFakeExecCmd("TestGetPythonVersionCmd", "not-present"))
-		assert.NotNil(t, err)
-		assert.Equal(t, "", pythonV)
-	})
-
 	t.Run("invalid Python version", func(t *testing.T) {
-		pythonV, err := getPythonVersion(pythonVersionFakeExecCmd("TestGetPythonVersionCmd", "invalid"))
+		pythonV, err := parsePythonVersion([]byte("gibberish"))
 		assert.NotNil(t, err)
 		assert.Equal(t, "", pythonV)
 	})
 }
 
-// TestGetHostnameShellCmd is a method that is called as a substitute for a shell command,
-// the GO_TEST_PROCESS flag ensures that if it is called as part of the test suite, it is skipped.
+func TestGetPythonVersion(t *testing.T) {
+	t.Run("valid command", func(t *testing.T) {
+		pythonV, err := getPythonVersion(utils.BuildFakeExecCmd("TestGetPythonVersionCmd", "valid-command"))
+		assert.Nil(t, err)
+		assert.Equal(t, "3.8.9", pythonV)
+	})
+
+	t.Run("Python not found", func(t *testing.T) {
+		pythonV, err := getPythonVersion(utils.BuildFakeExecCmd("TestGetPythonVersionCmd", "python-not-found"))
+		assert.NotNil(t, err)
+		assert.Equal(t, "", pythonV)
+	})
+}
+
+// TestGetHostnameShellCmd is a method that is called as a substitute for a shell command by the
+// fake ExecCmd built with utils.BuildFakeExecCmd("TestGetPythonVersionCmd", "foo").
+// The GO_TEST_PROCESS flag ensures that if it is called as part of the test suite, it is skipped.
 func TestGetPythonVersionCmd(t *testing.T) {
 	if os.Getenv("GO_TEST_PROCESS") != "1" {
 		return
@@ -49,24 +57,12 @@ func TestGetPythonVersionCmd(t *testing.T) {
 	assert.EqualValues(t, []string{"python", "-V"}, cmdList)
 
 	switch testRunName {
-	case "valid":
+	case "valid-command":
 		fmt.Fprintf(os.Stdout, "Python 3.8.9\n")
 		os.Exit(0)
-	case "valid-windows":
-		fmt.Fprintf(os.Stdout, "Python 3.8.9\r\n")
-		os.Exit(0)
-	case "not-present":
+	case "python-not-found":
 		fmt.Fprintf(os.Stdout, "")
 		fmt.Fprintf(os.Stderr, "command not found: python")
 		os.Exit(127)
-	case "invalid":
-		fmt.Fprintf(os.Stdout, "giberrish")
-		os.Exit(0)
-	}
-}
-
-func pythonVersionFakeExecCmd(testName string, testRunName string) utils.ExecCmdFunc {
-	return func(command string, args ...string) *exec.Cmd {
-		return utils.FakeExecCmd(testName, testRunName, command, args...)
 	}
 }

--- a/processes/gops/gops.go
+++ b/processes/gops/gops.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package gops
 
 import (

--- a/processes/gops/process_group.go
+++ b/processes/gops/process_group.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package gops
 
 import (

--- a/processes/gops/process_group_test.go
+++ b/processes/gops/process_group_test.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package gops
 
 import (

--- a/processes/gops/process_info.go
+++ b/processes/gops/process_info.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 // Extract the information on running processes from gopsutil
 package gops
 

--- a/utils/cmd.go
+++ b/utils/cmd.go
@@ -9,12 +9,11 @@ import (
 // ExecCmdFunc is a function type that matches exec.Command's signature
 type ExecCmdFunc = func(name string, arg ...string) *exec.Cmd
 
-// FakeExecCmd is a function that initialises a new exec.Cmd, one which will
+// fakeExecCmd is a function that initialises a new exec.Cmd, one which will
 // simply call the testName function rather than the command it is provided. It will
 // also pass through as arguments to the testName function the testRunName, the command and its
 // arguments.
-// See platform/platform_common_test.go for an example of how to use it to mock exec.Cmd in tests.
-func FakeExecCmd(testName string, testRunName string, command string, args ...string) *exec.Cmd {
+func fakeExecCmd(testName string, testRunName string, command string, args ...string) *exec.Cmd {
 	cs := []string{fmt.Sprintf("-test.run=%s", testName), "--", testRunName}
 	cs = append(cs, command)
 	cs = append(cs, args...)
@@ -23,9 +22,18 @@ func FakeExecCmd(testName string, testRunName string, command string, args ...st
 	return cmd
 }
 
-// ParseFakeExecCmdArgs parses the CLI's os.Args as passed by FakeExecCmd and returns the testRunName, and
-// cmdList.
-// Meant to be used from test functions that are called by FakeExecCmd.
+// BuildFakeExecCmd returns a fakeExecCmd for the testName and testRunName.
+// See platform/platform_common_test.go for an example of how to use it to mock exec.Cmd in tests.
+func BuildFakeExecCmd(testName string, testRunName string) ExecCmdFunc {
+	return func(command string, args ...string) *exec.Cmd {
+		return fakeExecCmd(testName, testRunName, command, args...)
+	}
+}
+
+// ParseFakeExecCmdArgs parses the CLI's os.Args as passed by fakeExecCmd and returns the
+// testRunName, and cmdList.
+// Meant to be used from test functions that are called by a fakeExecCmd built with
+// BuildFakeExecCmd.
 func ParseFakeExecCmdArgs() (string, []string) {
 	args := os.Args
 	for len(args) > 0 {

--- a/utils/cmd.go
+++ b/utils/cmd.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// ExecCmdFunc is a function type that matches exec.Command's signature
+type ExecCmdFunc = func(name string, arg ...string) *exec.Cmd
+
+// FakeExecCmd is a function that initialises a new exec.Cmd, one which will
+// simply call the testName function rather than the command it is provided. It will
+// also pass through as arguments to the testName function the testRunName, the command and its
+// arguments.
+// See platform/platform_common_test.go for an example of how to use it to mock exec.Cmd in tests.
+func FakeExecCmd(testName string, testRunName string, command string, args ...string) *exec.Cmd {
+	cs := []string{fmt.Sprintf("-test.run=%s", testName), "--", testRunName}
+	cs = append(cs, command)
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}
+
+// ParseFakeExecCmdArgs parses the CLI's os.Args as passed by FakeExecCmd and returns the testRunName, and
+// cmdList.
+// Meant to be used from test functions that are called by FakeExecCmd.
+func ParseFakeExecCmdArgs() (string, []string) {
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+
+	return args[0], args[1:]
+}


### PR DESCRIPTION
* Add CI with Github workflow, testing with 1 Go version (1.17.x) on linux/macOS/Windows. This requires putting behind unix-only build flags the tests and/or packages that only work on unix platforms.
* Add tests on the Python version collection logic, with a test pattern that we should hopefully be able to re-use in all the places where gohai uses `cmd.Exec`. Tests changes done in https://github.com/DataDog/gohai/pull/87.