### PR TITLE
Update expectedLength for Darwin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-10.15, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 func getFileSystemInfo() (interface{}, error) {
@@ -30,13 +32,18 @@ func getFileSystemInfo() (interface{}, error) {
 }
 
 func parseDfOutput(out string) (interface{}, error) {
+	var aggregateError error
 	lines := strings.Split(out, "\n")
 	var fileSystemInfo = make([]interface{}, len(lines)-2)
 	for i, line := range lines[1:] {
 		values := regexp.MustCompile(`\s+`).Split(line, -1)
 		if len(values) >= expectedLength {
-			fileSystemInfo[i] = updatefileSystemInfo(values)
+			var err error
+			fileSystemInfo[i], err = updatefileSystemInfo(values)
+			if err != nil {
+				aggregateError = multierror.Append(aggregateError, err)
+			}
 		}
 	}
-	return fileSystemInfo, nil
+	return fileSystemInfo, aggregateError
 }

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -33,8 +33,8 @@ func parseDfOutput(out string) (interface{}, error) {
 	lines := strings.Split(out, "\n")
 	var fileSystemInfo = make([]interface{}, len(lines)-2)
 	for i, line := range lines[1:] {
-		values := regexp.MustCompile("\\s+").Split(line, expectedLength)
-		if len(values) == expectedLength {
+		values := regexp.MustCompile(`\s+`).Split(line, -1)
+		if len(values) >= expectedLength {
 			fileSystemInfo[i] = updatefileSystemInfo(values)
 		}
 	}

--- a/filesystem/filesystem_darwin.go
+++ b/filesystem/filesystem_darwin.go
@@ -7,6 +7,6 @@ func updatefileSystemInfo(values []string) map[string]string {
 	return map[string]string{
 		"name":       values[0],
 		"kb_size":    values[1],
-		"mounted_on": values[8],
+		"mounted_on": values[5],
 	}
 }

--- a/filesystem/filesystem_darwin.go
+++ b/filesystem/filesystem_darwin.go
@@ -1,7 +1,7 @@
 package filesystem
 
 var dfOptions = []string{"-l", "-k"}
-var expectedLength = 9
+var expectedLength = 6
 
 func updatefileSystemInfo(values []string) map[string]string {
 	return map[string]string{

--- a/filesystem/filesystem_darwin.go
+++ b/filesystem/filesystem_darwin.go
@@ -1,20 +1,24 @@
 package filesystem
 
+import "fmt"
+
 var dfOptions = []string{"-l", "-k"}
 var expectedLength = 6
 
-func updatefileSystemInfo(values []string) map[string]string {
+func updatefileSystemInfo(values []string) (map[string]string, error) {
+	// On some MacOS systems df outputs 9 columns, on others 6
 	if len(values) == 9 {
 		return map[string]string{
 			"name":       values[0],
 			"kb_size":    values[1],
 			"mounted_on": values[8],
-		}
-	} else {
+		}, nil
+	} else if len(values) == 6 {
 		return map[string]string{
 			"name":       values[0],
 			"kb_size":    values[1],
 			"mounted_on": values[5],
-		}
+		}, nil
 	}
+	return nil, fmt.Errorf("unexpected df output with %d columns", len(values))
 }

--- a/filesystem/filesystem_darwin.go
+++ b/filesystem/filesystem_darwin.go
@@ -4,9 +4,17 @@ var dfOptions = []string{"-l", "-k"}
 var expectedLength = 6
 
 func updatefileSystemInfo(values []string) map[string]string {
-	return map[string]string{
-		"name":       values[0],
-		"kb_size":    values[1],
-		"mounted_on": values[5],
+	if len(values) == 9 {
+		return map[string]string{
+			"name":       values[0],
+			"kb_size":    values[1],
+			"mounted_on": values[8],
+		}
+	} else {
+		return map[string]string{
+			"name":       values[0],
+			"kb_size":    values[1],
+			"mounted_on": values[5],
+		}
 	}
 }

--- a/filesystem/filesystem_linux.go
+++ b/filesystem/filesystem_linux.go
@@ -3,10 +3,10 @@ package filesystem
 var dfOptions = []string{"-l"}
 var expectedLength = 6
 
-func updatefileSystemInfo(values []string) map[string]string {
+func updatefileSystemInfo(values []string) (map[string]string, error) {
 	return map[string]string{
 		"name":       values[0],
 		"kb_size":    values[1],
 		"mounted_on": values[5],
-	}
+	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/shirou/gopsutil/v3 v3.22.2
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20220111092808-5a964db01320

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,10 @@ github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiU
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
On MacOS 12.3, `df -l -k` produces an output with 6 columns:
```
> df -l -k
Filesystem     1K-blocks      Used Available Use% Mounted on
/dev/disk1s5s1 488245288 311248912 176996376  64% /
/dev/disk1s4   488245288 311248912 176996376  64% /System/Volumes/VM
/dev/disk1s2   488245288 311248912 176996376  64% /System/Volumes/Preboot
/dev/disk1s6   488245288 311248912 176996376  64% /System/Volumes/Update
/dev/disk1s5   488245288 311248912 176996376  64% /System/Volumes/Update/mnt1
```