### PR TITLE
Be more robust to failures in `df`

### DIFF
--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -4,6 +4,7 @@ package filesystem
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -13,35 +14,55 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+var dfCommand = "df"
+var dfTimeout = 2 * time.Second
+
 func getFileSystemInfo() (interface{}, error) {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), dfTimeout)
 	defer cancel()
 
 	/* Grab filesystem data from df	*/
-	cmd := exec.CommandContext(ctx, "df", dfOptions...)
+	cmd := exec.CommandContext(ctx, dfCommand, dfOptions...)
 
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("df failed to collect filesystem data: %s", err)
-	}
+	out, execErr := cmd.Output()
+	var parseErr error
+	var result []interface{}
 	if out != nil {
-		return parseDfOutput(string(out))
+		result, parseErr = parseDfOutput(string(out))
 	}
-	return nil, fmt.Errorf("df failed to collect filesystem data")
+
+	// if we managed to get _any_ data, just use it, ignoring other errors
+	if result != nil && len(result) != 0 {
+		return result, nil
+	}
+
+	// otherwise, prefer the parse error, as it is probably more detailed
+	err := execErr
+	if parseErr != nil {
+		err = parseErr
+	}
+	if err == nil {
+		err = errors.New("unknown error")
+	}
+	return nil, fmt.Errorf("df failed to collect filesystem data: %s", parseErr)
 }
 
-func parseDfOutput(out string) (interface{}, error) {
+func parseDfOutput(out string) ([]interface{}, error) {
 	var aggregateError error
 	lines := strings.Split(out, "\n")
-	var fileSystemInfo = make([]interface{}, len(lines)-2)
-	for i, line := range lines[1:] {
+	if len(lines) < 2 {
+		return nil, errors.New("no output")
+	}
+	var fileSystemInfo = make([]interface{}, 0, len(lines)-2)
+	for _, line := range lines[1:] {
 		values := regexp.MustCompile(`\s+`).Split(line, -1)
 		if len(values) >= expectedLength {
-			var err error
-			fileSystemInfo[i], err = updatefileSystemInfo(values)
+			info, err := updatefileSystemInfo(values)
 			if err != nil {
 				aggregateError = multierror.Append(aggregateError, err)
+			} else {
+				fileSystemInfo = append(fileSystemInfo, info)
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/shirou/gopsutil/v3 v3.22.2
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.8.0
 	golang.org/x/sys v0.0.0-20220111092808-5a964db01320
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,12 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:Om
 github.com/shirou/gopsutil/v3 v3.22.2 h1:wCrArWFkHYIdDxx/FSfF5RB4dpJYW6t7rcp3+zL8uks=
 github.com/shirou/gopsutil/v3 v3.22.2/go.mod h1:WapW1AOOPlHyXr+yOyw3uYx36enocrtSoSBy0L5vUHY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
 github.com/tklauser/numcpus v0.3.0 h1:ILuRUQBtssgnxw0XXIjKUC56fgnOrFoQQ/4+DeU2biQ=
@@ -40,3 +44,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
A few things changed here:
 * `exec.Cmd#Output` returns output even if there is an error, although this isn't documented.  So, parse that output if it's present, and only return the error if there's no useful data
 * Don't parse blank lines as `nil` in the returned array
 * Replace `TestSlowGetFileSystemInfo`, which was only testing `MockSlowGetFileSystemInfo` and not any real code, with an actual test.
 * Use a newer version of `require` to get ErrorContains.