### PR TITLE
Remove deprecated macos-10.15 image version in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-latest, macos-11, macos-latest, windows-2019, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
MacOS 10.15 version is deprecated in Github actions and will be removed fully on March 31st (see https://github.com/actions/runner-images/issues/5583).

This PR simply removes the image from the CI.

The image was added by https://github.com/DataDog/gohai/pull/94 because `df` was found to have a different output format on this version of MacOS compared to more recent versions, but actually the format is the same on the Github actions images macos-10.15, macos-11 and macos-12 (see below), so I guess it depends on the version of `df` itself (or maybe some locale) and not really the version of macos.

I edited the CI to simply run `df -lk` on the 3 versions mentioned above and all 3 had the same format
https://github.com/DataDog/gohai/actions/runs/4282036989

Fixes https://datadoghq.atlassian.net/browse/ASC-413.