### PR TITLE
Fix various error-related lints

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -138,6 +138,8 @@ func getSystemInfo() (si SYSTEM_INFO) {
 	var mod = syscall.NewLazyDLL("kernel32.dll")
 	var gsi = mod.NewProc("GetSystemInfo")
 
+	// syscall does not fail
+	//nolint:errcheck
 	gsi.Call(uintptr(unsafe.Pointer(&si)))
 	return
 }
@@ -150,6 +152,8 @@ func GetCpuInfo() (cpuInfo map[string]string, err error) {
 		registryHive,
 		registry.QUERY_VALUE)
 	if err == nil {
+		// ignore registry key close errors
+		//nolint:staticcheck
 		defer k.Close()
 
 		dw, _, err := k.GetIntegerValue("~MHz")

--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -144,39 +144,53 @@ func getSystemInfo() (si SYSTEM_INFO) {
 
 // GetCpuInfo returns map of interesting bits of information about the CPU
 func GetCpuInfo() (cpuInfo map[string]string, err error) {
-
 	cpuInfo = make(map[string]string)
-
-	cpus, _ := computeCoresAndProcessors()
-	si := getSystemInfo()
 
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
 		registryHive,
 		registry.QUERY_VALUE)
-	defer k.Close()
-	dw, _, err := k.GetIntegerValue("~MHz")
-	cpuInfo["mhz"] = strconv.Itoa(int(dw))
+	if err == nil {
+		defer k.Close()
 
-	s, _, err := k.GetStringValue("ProcessorNameString")
-	cpuInfo["model_name"] = s
+		dw, _, err := k.GetIntegerValue("~MHz")
+		if err == nil {
+			cpuInfo["mhz"] = strconv.Itoa(int(dw))
+		}
 
-	cpuInfo["cpu_pkgs"] = strconv.Itoa(cpus.pkgcount)
-	cpuInfo["cpu_numa_nodes"] = strconv.Itoa(cpus.numaNodeCount)
-	cpuInfo["cpu_cores"] = strconv.Itoa(cpus.corecount)
-	cpuInfo["cpu_logical_processors"] = strconv.Itoa(cpus.logicalcount)
+		s, _, err := k.GetStringValue("ProcessorNameString")
+		if err == nil {
+			cpuInfo["model_name"] = s
+		}
 
-	s, _, err = k.GetStringValue("VendorIdentifier")
-	cpuInfo["vendor_id"] = s
+		s, _, err = k.GetStringValue("VendorIdentifier")
+		if err == nil {
+			cpuInfo["vendor_id"] = s
+		}
 
-	s, _, err = k.GetStringValue("Identifier")
-	cpuInfo["family"] = extract(s, "Family")
+		s, _, err = k.GetStringValue("Identifier")
+		if err == nil {
+			cpuInfo["family"] = extract(s, "Family")
+		}
+	}
 
+	cpus, err := computeCoresAndProcessors()
+	if err == nil {
+		cpuInfo["cpu_pkgs"] = strconv.Itoa(cpus.pkgcount)
+		cpuInfo["cpu_numa_nodes"] = strconv.Itoa(cpus.numaNodeCount)
+		cpuInfo["cpu_cores"] = strconv.Itoa(cpus.corecount)
+		cpuInfo["cpu_logical_processors"] = strconv.Itoa(cpus.logicalcount)
+
+		cpuInfo["cache_size_l1"] = strconv.Itoa(int(cpus.l1CacheSize))
+		cpuInfo["cache_size_l2"] = strconv.Itoa(int(cpus.l2CacheSize))
+		cpuInfo["cache_size_l3"] = strconv.Itoa(int(cpus.l3CacheSize))
+	}
+
+	si := getSystemInfo()
 	cpuInfo["model"] = strconv.Itoa(int((si.wProcessorRevision >> 8) & 0xFF))
 	cpuInfo["stepping"] = strconv.Itoa(int(si.wProcessorRevision & 0xFF))
 
-	cpuInfo["cache_size_l1"] = strconv.Itoa(int(cpus.l1CacheSize))
-	cpuInfo["cache_size_l2"] = strconv.Itoa(int(cpus.l2CacheSize))
-	cpuInfo["cache_size_l3"] = strconv.Itoa(int(cpus.l3CacheSize))
+	// cpuInfo cannot be empty
+	err = nil
 
 	return
 }

--- a/cpu/cpu_windows_amd64.go
+++ b/cpu/cpu_windows_amd64.go
@@ -104,34 +104,34 @@ func byteArrayToRelationGroup(data []byte) (group GROUP_RELATIONSHIP, gi []PROCE
 	return
 }
 
-func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
+func computeCoresAndProcessors() (CPU_INFO, error) {
+	var cpuInfo CPU_INFO
 	var mod = syscall.NewLazyDLL("kernel32.dll")
 	var getProcInfo = mod.NewProc("GetLogicalProcessorInformationEx")
 	var buflen uint32 = 0
 
 	// first, figure out how much we need
-	status, _, err := getProcInfo.Call(uintptr(0xFFFF), // all relationships.
+	status, _, callErr := getProcInfo.Call(uintptr(0xFFFF), // all relationships.
 		uintptr(0),
 		uintptr(unsafe.Pointer(&buflen)))
 	if status == 0 {
-		if err != ERROR_INSUFFICIENT_BUFFER {
+		if callErr != ERROR_INSUFFICIENT_BUFFER {
 			// only error we're expecing here is insufficient buffer
 			// anything else is a failure
-			return
+			return cpuInfo, callErr
 		}
 	} else {
 		// this shouldn't happen. Errno won't be set (because the function)
 		// succeeded.  So just return something to indicate we've failed
-		err = syscall.Errno(1)
-		return
+		return cpuInfo, syscall.Errno(1)
 	}
 	buf := make([]byte, buflen)
-	status, _, err = getProcInfo.Call(
+	status, _, callErr = getProcInfo.Call(
 		uintptr(0xFFFF), // still want all relationships
 		uintptr(unsafe.Pointer(&buf[0])),
 		uintptr(unsafe.Pointer(&buflen)))
 	if status == 0 {
-		return
+		return cpuInfo, callErr
 	}
 	// walk through each of the buffers
 
@@ -139,8 +139,7 @@ func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
 	for bufused < buflen {
 		info, used, decodeerr := byteArrayToProcessorInformationExStruct(buf[bufused:])
 		if decodeerr != nil {
-			err = decodeerr
-			return
+			return cpuInfo, decodeerr
 		}
 		bufused += used
 		if info.Size == 0 {
@@ -150,8 +149,7 @@ func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
 		case RelationProcessorCore:
 			core, groupMask, used, decodeerr := byteArrayToProcessorRelationshipStruct(buf[bufused:])
 			if decodeerr != nil {
-				err = decodeerr
-				return
+				return cpuInfo, decodeerr
 			}
 			bufused += used
 			cpuInfo.corecount++
@@ -161,8 +159,7 @@ func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
 		case RelationNumaNode:
 			_, used, decodeerr := byteArrayToNumaNode(buf[bufused:])
 			if decodeerr != nil {
-				err = decodeerr
-				return
+				return cpuInfo, decodeerr
 			}
 			cpuInfo.numaNodeCount++
 			bufused += used
@@ -170,8 +167,7 @@ func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
 		case RelationCache:
 			cache, used, decodeerr := byteArrayToRelationCache(buf[bufused:])
 			if decodeerr != nil {
-				err = decodeerr
-				return
+				return cpuInfo, decodeerr
 			}
 			bufused += used
 			switch cache.Level {
@@ -185,8 +181,7 @@ func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
 		case RelationProcessorPackage:
 			_, _, used, decodeerr := byteArrayToProcessorRelationshipStruct(buf[bufused:])
 			if decodeerr != nil {
-				err = decodeerr
-				return
+				return cpuInfo, decodeerr
 			}
 			bufused += used
 			cpuInfo.pkgcount++
@@ -194,8 +189,7 @@ func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
 		case RelationGroup:
 			group, groupInfo, used, decodeerr := byteArrayToRelationGroup(buf[bufused:])
 			if decodeerr != nil {
-				err = decodeerr
-				return
+				return cpuInfo, decodeerr
 			}
 			bufused += used
 			cpuInfo.relationGroups += int(group.MaximumGroupCount)
@@ -207,6 +201,5 @@ func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
 		}
 	}
 
-	err = nil
-	return
+	return cpuInfo, nil
 }

--- a/cpu/cpu_windows_amd64.go
+++ b/cpu/cpu_windows_amd64.go
@@ -61,7 +61,6 @@ func byteArrayToProcessorRelationshipStruct(data []byte) (proc PROCESSOR_RELATIO
 }
 
 func byteArrayToNumaNode(data []byte) (numa NUMA_NODE_RELATIONSHIP, consumed uint32, err error) {
-	err = nil
 	numa.NodeNumber = uint32(binary.LittleEndian.Uint32(data))
 	// skip 20 bytes of reserved
 	consumed = 24
@@ -110,7 +109,6 @@ func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
 	var getProcInfo = mod.NewProc("GetLogicalProcessorInformationEx")
 	var buflen uint32 = 0
 
-	err = syscall.Errno(0)
 	// first, figure out how much we need
 	status, _, err := getProcInfo.Call(uintptr(0xFFFF), // all relationships.
 		uintptr(0),

--- a/cpu/cpu_windows_amd64.go
+++ b/cpu/cpu_windows_amd64.go
@@ -207,5 +207,6 @@ func computeCoresAndProcessors() (cpuInfo CPU_INFO, err error) {
 		}
 	}
 
+	err = nil
 	return
 }

--- a/filesystem/filesystem.go
+++ b/filesystem/filesystem.go
@@ -35,7 +35,7 @@ func getFileSystemInfo() (interface{}, error) {
 	}
 
 	// if we managed to get _any_ data, just use it, ignoring other errors
-	if result != nil && len(result) != 0 {
+	if len(result) != 0 {
 		return result, nil
 	}
 
@@ -47,7 +47,7 @@ func getFileSystemInfo() (interface{}, error) {
 	if err == nil {
 		err = errors.New("unknown error")
 	}
-	return nil, fmt.Errorf("df failed to collect filesystem data: %s", parseErr)
+	return nil, fmt.Errorf("df failed to collect filesystem data: %s", err)
 }
 
 func parseDfOutput(out string) ([]interface{}, error) {

--- a/filesystem/filesystem_windows.go
+++ b/filesystem/filesystem_windows.go
@@ -76,7 +76,7 @@ func getMountPoints(vol string) []string {
 		return retval
 	}
 	buf := make([]uint16, objlistsize)
-	status, _, errno = getPaths.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(vol))),
+	status, _, _ = getPaths.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(vol))),
 		uintptr(unsafe.Pointer(&buf[0])),
 		uintptr(objlistsize),
 		uintptr(unsafe.Pointer(&objlistsize)))

--- a/filesystem/filesystem_windows.go
+++ b/filesystem/filesystem_windows.go
@@ -66,7 +66,11 @@ func getMountPoints(vol string) []string {
 	var objlistsize uint32 = 0x0
 	var retval []string
 
-	status, _, errno := getPaths.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(vol))),
+	volWinStr, err := syscall.UTF16PtrFromString(vol)
+	if err != nil {
+		return retval
+	}
+	status, _, errno := getPaths.Call(uintptr(unsafe.Pointer(volWinStr)),
 		uintptr(unsafe.Pointer(&tmp)),
 		2,
 		uintptr(unsafe.Pointer(&objlistsize)))
@@ -75,8 +79,9 @@ func getMountPoints(vol string) []string {
 		// unexpected
 		return retval
 	}
+
 	buf := make([]uint16, objlistsize)
-	status, _, _ = getPaths.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(vol))),
+	status, _, _ = getPaths.Call(uintptr(unsafe.Pointer(volWinStr)),
 		uintptr(unsafe.Pointer(&buf[0])),
 		uintptr(objlistsize),
 		uintptr(unsafe.Pointer(&objlistsize)))

--- a/filesystem/filesystem_windows.go
+++ b/filesystem/filesystem_windows.go
@@ -43,6 +43,7 @@ func convert_windows_string(winput []uint16) string {
 	}
 	return retstring
 }
+
 func getDiskSize(vol string) (size uint64, freespace uint64) {
 	var mod = syscall.NewLazyDLL("kernel32.dll")
 	var getDisk = mod.NewProc("GetDiskFreeSpaceExW")
@@ -57,6 +58,7 @@ func getDiskSize(vol string) (size uint64, freespace uint64) {
 	}
 	return sz, fr
 }
+
 func getMountPoints(vol string) []string {
 	var mod = syscall.NewLazyDLL("kernel32.dll")
 	var getPaths = mod.NewProc("GetVolumePathNamesForVolumeNameW")
@@ -84,6 +86,7 @@ func getMountPoints(vol string) []string {
 	return convert_windows_string_list(buf)
 
 }
+
 func getFileSystemInfo() (interface{}, error) {
 	var mod = syscall.NewLazyDLL("kernel32.dll")
 	var findFirst = mod.NewProc("FindFirstVolumeW")
@@ -99,6 +102,8 @@ func getFileSystemInfo() (interface{}, error) {
 	var fileSystemInfo []interface{}
 
 	if findHandle != InvalidHandle {
+		// ignore close error
+		//nolint:staticcheck
 		defer findClose.Call(fh)
 		moreData := true
 		for moreData {

--- a/filesystem/filesystem_windows.go
+++ b/filesystem/filesystem_windows.go
@@ -49,7 +49,12 @@ func getDiskSize(vol string) (size uint64, freespace uint64) {
 	var getDisk = mod.NewProc("GetDiskFreeSpaceExW")
 	var sz uint64
 	var fr uint64
-	status, _, _ := getDisk.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(vol))),
+
+	volWinStr, err := syscall.UTF16PtrFromString(vol)
+	if err != nil {
+		return 0, 0
+	}
+	status, _, _ := getDisk.Call(uintptr(unsafe.Pointer(volWinStr)),
 		uintptr(0),
 		uintptr(unsafe.Pointer(&sz)),
 		uintptr(unsafe.Pointer(&fr)))
@@ -108,7 +113,7 @@ func getFileSystemInfo() (interface{}, error) {
 
 	if findHandle != InvalidHandle {
 		// ignore close error
-		//nolint:staticcheck
+		//nolint:errcheck
 		defer findClose.Call(fh)
 		moreData := true
 		for moreData {

--- a/platform/platform_windows.go
+++ b/platform/platform_windows.go
@@ -113,6 +113,8 @@ func fetchOsDescription() (string, error) {
 				// ignore free errors
 				//nolint:errcheck
 				defer syscall.LocalFree(syscall.Handle(os))
+				// govet complains about possible misuse of unsafe.Pointer here
+				//nolint:govet
 				return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(os))), nil
 			}
 		}

--- a/platform/platform_windows.go
+++ b/platform/platform_windows.go
@@ -95,7 +95,7 @@ func netServerGetInfo() (si SERVER_INFO_101, err error) {
 		return
 	}
 	// ignore free errors
-	//nolint:staticcheck
+	//nolint:errcheck
 	defer procNetApiBufferFree.Call(uintptr(unsafe.Pointer(outdata)))
 	return platGetServerInfo(outdata), nil
 }

--- a/platform/platform_windows.go
+++ b/platform/platform_windows.go
@@ -94,6 +94,8 @@ func netServerGetInfo() (si SERVER_INFO_101, err error) {
 	if status != uintptr(0) {
 		return
 	}
+	// ignore free errors
+	//nolint:staticcheck
 	defer procNetApiBufferFree.Call(uintptr(unsafe.Pointer(outdata)))
 	return platGetServerInfo(outdata), nil
 }
@@ -108,6 +110,8 @@ func fetchOsDescription() (string, error) {
 			magicString := utf16.Encode([]rune("%WINDOWS_LONG%" + "\x00"))
 			os, _, err := procBrandingFormatString.Call(uintptr(unsafe.Pointer(&magicString[0])))
 			if err == ERROR_SUCESS {
+				// ignore free errors
+				//nolint:errcheck
 				defer syscall.LocalFree(syscall.Handle(os))
 				return windows.UTF16PtrToString((*uint16)(unsafe.Pointer(os))), nil
 			}
@@ -118,6 +122,8 @@ func fetchOsDescription() (string, error) {
 		registryHive,
 		registry.QUERY_VALUE)
 	if err == nil {
+		// ignore registry key close errors
+		//nolint:staticcheck
 		defer k.Close()
 		os, _, err := k.GetStringValue(productNameKey)
 		if err == nil {
@@ -143,6 +149,8 @@ func fetchWindowsVersion() (major uint64, minor uint64, build uint64, err error)
 		if err != nil {
 			return
 		}
+		// ignore registry key close errors
+		//nolint:staticcheck
 		defer regkey.Close()
 		major, _, err = regkey.GetIntegerValue(majorKey)
 		if err != nil {


### PR DESCRIPTION
This PR is part of the effort to import gohai directly in the agent, for which we have to pass the agent's linters.

It solves the following lint warnings:
- variable unused (typically an error is stored but not used)
- function returns an error but it is not checked
- defer (eg. Close or Free) before checking whether there was an error
- use of deprecated function
- possible unsafe use of `unsafe.Pointer`

Note: some `//nolint` were used for convenience (mostly to ignore warnings about defer-ing functions which return an error), they will be removed as much as possible in future PRs.

Note: requesting review from @DataDog/windows-agent as most of the changes are in windows files.

Jira ticket: https://datadoghq.atlassian.net/browse/ASC-495