### PR TITLE
Return default values for fields that were removed in #169

### DIFF
--- a/cpu/cpu_windows.go
+++ b/cpu/cpu_windows.go
@@ -218,8 +218,25 @@ func getSystemInfo() (si SYSTEM_INFO) {
 }
 
 // GetCpuInfo returns map of interesting bits of information about the CPU
-func GetCpuInfo() (cpuInfo map[string]string, err error) {
-	cpuInfo = make(map[string]string)
+func GetCpuInfo() (map[string]string, error) {
+	// Initialize cpuInfo with all fields to avoid missing a field which
+	// could be expected by the backend or by users
+	// TODO: make sure that the backend actually works with any subset of fields
+	cpuInfo := map[string]string{
+		"mhz":                    "0",
+		"model_name":             "",
+		"vendor_id":              "",
+		"family":                 "",
+		"cpu_pkgs":               "0",
+		"cpu_numa_nodes":         "0",
+		"cpu_cores":              "0",
+		"cpu_logical_processors": "0",
+		"cache_size_l1":          "0",
+		"cache_size_l2":          "0",
+		"cache_size_l3":          "0",
+		"model":                  "0",
+		"stepping":               "0",
+	}
 
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
 		registryHive,
@@ -266,10 +283,7 @@ func GetCpuInfo() (cpuInfo map[string]string, err error) {
 	cpuInfo["model"] = strconv.Itoa(int((si.wProcessorRevision >> 8) & 0xFF))
 	cpuInfo["stepping"] = strconv.Itoa(int(si.wProcessorRevision & 0xFF))
 
-	// cpuInfo cannot be empty
-	err = nil
-
-	return
+	return cpuInfo, nil
 }
 
 func extract(caption, field string) string {

--- a/platform/platform_windows.go
+++ b/platform/platform_windows.go
@@ -295,8 +295,18 @@ func getNativeArchInfo() string {
 }
 
 // GetArchInfo returns basic host architecture information
-func GetArchInfo() (systemInfo map[string]string, err error) {
-	systemInfo = map[string]string{}
+func GetArchInfo() (map[string]string, error) {
+	// Initialize systemInfo with all fields to avoid missing a field which
+	// could be expected by the backend or by users
+	// TODO: make sure that the backend actually works with any subset of fields
+	systemInfo := map[string]string{
+		"hostname":       "",
+		"machine":        "",
+		"os":             "",
+		"kernel_release": "0.0.0",
+		"kernel_name":    "",
+		"family":         "",
+	}
 
 	hostname, err := os.Hostname()
 	if err == nil {
@@ -343,8 +353,5 @@ func GetArchInfo() (systemInfo map[string]string, err error) {
 	}
 	systemInfo["family"] = family
 
-	// systemInfo is never empty so we never return an error
-	err = nil
-
-	return
+	return systemInfo, nil
 }


### PR DESCRIPTION
https://github.com/DataDog/gohai/pull/169 fixed various unused error lint warnings, but it changed the behavior of some functions, which instead of returning a default value in case of error now don't return the value.

No one is really sure that this is supported by the backend, and it would break users of gohai which might expects these fields to always be there (some pieces of the agent actually do).

This PR reverts this change to be safe.