### PR TITLE
Warn that Gohai was moved to datadog-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Gohai is a tool which collects an inventory of system information. It aims to implement some parts of features from [facter](https://github.com/puppetlabs/facter) and [ohai](https://github.com/opscode/ohai).  It's forked from Kentaro Kuribayashi's [verity](https://github.com/kentaro/verity).
 
-## **:warning: Gohai now lives in the repository of the [datadog-agent](https://github.com/DataDog/datadog-agent), under the `/pkg/gohai` directory, as an independent module **
+## :warning: Gohai now lives in the repository of the [datadog-agent](https://github.com/DataDog/datadog-agent), under the `/pkg/gohai` directory, as an independent module :warning:
 
 Bug reports and feature requests should be addressed to the new parent repository ([datadog-agent](https://github.com/DataDog/datadog-agent)).
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ In order to update to the most recent version of Gohai, you have to replace `git
 
 Note that the API was changed so verify that the API calls that you are using did not change in the new destination.
 
+This repository will likely be archived soon.
+
 ## Usage
 
 Gohai will build and install with `go get`. We require at least Go 1.17.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@
 
 Gohai is a tool which collects an inventory of system information. It aims to implement some parts of features from [facter](https://github.com/puppetlabs/facter) and [ohai](https://github.com/opscode/ohai).  It's forked from Kentaro Kuribayashi's [verity](https://github.com/kentaro/verity).
 
+**:warning:** Gohai now lives in the repository of the [datadog-agent](https://github.com/DataDog/datadog-agent), under `/pkg/gohai`.
+
+Bug reports and feature requests should be addressed to https://github.com/DataDog/datadog-agent.
+
+In order to update to the most recent version of Gohai, you have to replace `github.com/DataDog/gohai` with `github.com/DataDog/datadog-agent/pkg/gohai`.
+Note that the API was changed so don't do it blindly.
+
 ## Usage
 
-Gohai will build and install with `go get`. We require at least Go 1.7.
+Gohai will build and install with `go get`. We require at least Go 1.17.
 
 ```sh
 go get github.com/DataDog/gohai

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 Gohai is a tool which collects an inventory of system information. It aims to implement some parts of features from [facter](https://github.com/puppetlabs/facter) and [ohai](https://github.com/opscode/ohai).  It's forked from Kentaro Kuribayashi's [verity](https://github.com/kentaro/verity).
 
-**:warning:** Gohai now lives in the repository of the [datadog-agent](https://github.com/DataDog/datadog-agent), under `/pkg/gohai`.
+## **:warning: Gohai now lives in the repository of the [datadog-agent](https://github.com/DataDog/datadog-agent), under the `/pkg/gohai` directory, as an independent module **
 
-Bug reports and feature requests should be addressed to https://github.com/DataDog/datadog-agent.
+Bug reports and feature requests should be addressed to the new parent repository ([datadog-agent](https://github.com/DataDog/datadog-agent)).
 
 In order to update to the most recent version of Gohai, you have to replace `github.com/DataDog/gohai` with `github.com/DataDog/datadog-agent/pkg/gohai`.
-Note that the API was changed so don't do it blindly.
+Note that the API was changed so verify that the API calls that you are using did not change in the new destination.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Gohai is a tool which collects an inventory of system information. It aims to im
 
 Bug reports and feature requests should be addressed to the new parent repository ([datadog-agent](https://github.com/DataDog/datadog-agent)).
 
-In order to update to the most recent version of Gohai, you have to replace `github.com/DataDog/gohai` with `github.com/DataDog/datadog-agent/pkg/gohai`.
+In order to update to the most recent version of Gohai, you have to replace `github.com/DataDog/gohai` with `github.com/DataDog/datadog-agent/pkg/gohai` in your `go.mod` and your imports.
+
 Note that the API was changed so verify that the API calls that you are using did not change in the new destination.
 
 ## Usage


### PR DESCRIPTION
This PR updates the README to warn users that Gohai is now hosted in the datadog-agent's github repository, mention the new path to use Gohai as a go dependency and warn that the API was changed.

> **:warning:** Gohai now lives in the repository of the [datadog-agent](https://github.com/DataDog/datadog-agent), under `/pkg/gohai`.
>
> Bug reports and feature requests should be addressed to https://github.com/DataDog/datadog-agent.
>
> In order to update to the most recent version of Gohai, you have to replace `github.com/DataDog/gohai` with `github.com/DataDog/datadog-agent/pkg/gohai`.
> Note that the API was changed so don't do it blindly.

It also fixes the minimum go version mentioned in the Readme to 1.17.